### PR TITLE
Add predefined resource name for TX

### DIFF
--- a/packages/web-app-cast/l10n/.tx/config
+++ b/packages/web-app-cast/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud-web:r:web-extensions-cast]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-extensions-cast
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-draw-io/l10n/.tx/config
+++ b/packages/web-app-draw-io/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud-web:r:web-extensions-draw-io]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-extensions-draw-io
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-external-sites/l10n/.tx/config
+++ b/packages/web-app-external-sites/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud-web:r:web-extensions-external-sites]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-extensions-external-sites
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-importer/l10n/.tx/config
+++ b/packages/web-app-importer/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud-web:r:web-extensions-importer]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-extensions-importer
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-json-viewer/l10n/.tx/config
+++ b/packages/web-app-json-viewer/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud-web:r:web-extensions-json-viewer]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-extensions-json-viewer
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-progress-bars/l10n/.tx/config
+++ b/packages/web-app-progress-bars/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud-web:r:web-extensions-progress-bars]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-extensions-progress-bars
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-unzip/l10n/.tx/config
+++ b/packages/web-app-unzip/l10n/.tx/config
@@ -4,6 +4,7 @@ host = https://www.transifex.com
 [o:owncloud-org:p:owncloud-web:r:web-extensions-unzip]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-extensions-unzip
 source_file = template.pot
 source_lang = en
 type = PO


### PR DESCRIPTION
Fixes: #97 (Resource naming for translations will not work as expected)

As discussed in the referenced PR with @kulmann 

This PR adds the `resource_name` config to the Translation definition for each web-extension. Doing so, you do not need to manually rename the resource in Transifex which needs elevated permissions. Though everything is already done in TX, adding this here makes each app a template for any upcoming app.