### PR TITLE
[test-only] add e2e tests to CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,6 +1,8 @@
 OC_CI_NODEJS = "owncloudci/nodejs:18"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
+PLUGINS_S3 = "plugins/s3:1.4.0"
+OC_UBUNTU = "owncloud/ubuntu:20.04"
 
 PLUGINS_DOCKER = "plugins/docker:20.14"
 PLUGINS_GITHUB_RELEASE = "plugins/github-release:1"
@@ -13,6 +15,10 @@ APPS = [
     "json-viewer",
     "progress-bars",
     "unzip",
+]
+
+APPS_COVERED_E2E = [
+    "draw-io",
 ]
 
 def main(ctx):
@@ -81,7 +87,7 @@ def beforePipelines(ctx):
     return checkStarlark()
 
 def stagePipelines(ctx):
-    return checks(ctx) + unitTests(ctx)
+    return checks(ctx) + unitTests(ctx) + e2eTests(ctx)
 
 def afterPipelines(ctx):
     return appBuilds(ctx)
@@ -313,3 +319,153 @@ def appBuilds(ctx):
             ],
         },
     }]
+
+def ocisService():
+    environment = {
+        "OCIS_URL": "https://ocis:9200",
+        "OCIS_INSECURE": "true",
+        "OCIS_LOG_LEVEL": "error",
+        "IDM_ADMIN_PASSWORD": "admin",
+        "PROXY_ENABLE_BASIC_AUTH": True,
+        "WEB_ASSET_APPS_PATH": "/var/lib/ocis/web/apps",
+        "WEB_UI_CONFIG_FILE": "/var/lib/ocis/web/config.json",
+    }
+
+    app_build_steps = [
+        {
+            "name": "build-web",
+            "image": OC_CI_NODEJS,
+            "commands": [
+                "pnpm build",
+                "mkdir -p /apps",
+                "mv packages/web-app-draw-io/dist /apps/draw-io",
+            ],
+            "volumes": [
+                {
+                    "name": "apps",
+                    "path": "/apps",
+                },
+            ],
+        },
+    ]
+
+    ocis_service = [
+        {
+            "name": "ocis",
+            "image": "owncloud/ocis-rolling:master",
+            "detach": True,
+            "environment": environment,
+            "commands": [
+                "mkdir -p /var/lib/ocis/web/apps",
+                "cp support/drone/ocis.web.config.json /var/lib/ocis/web/config.json",
+                "cp dev/docker/ocis.apps.yaml /var/lib/ocis/apps.yaml",
+                "cp -r /apps/* /var/lib/ocis/web/apps/",
+                "ocis init || true && ocis server",
+            ],
+            "volumes": [
+                {
+                    "name": "apps",
+                    "path": "/apps",
+                },
+            ],
+        },
+    ]
+
+    wait_for_ocis = [
+        {
+            "name": "wait-for-ocis",
+            "image": OC_CI_ALPINE,
+            "commands": [
+                "timeout 200 bash -c 'while [ $(curl -sk -uadmin:admin " +
+                "%s/graph/v1.0/users/admin " % environment["OCIS_URL"] +
+                "-w %{http_code} -o /dev/null) != 200 ]; do sleep 1; done'",
+            ],
+        },
+    ]
+
+    return app_build_steps + ocis_service + wait_for_ocis
+
+def uploadTracingResult(ctx):
+    return [{
+        "name": "upload-tracing-result",
+        "image": PLUGINS_S3,
+        "pull": "if-not-exists",
+        "settings": {
+            "bucket": {
+                "from_secret": "cache_public_s3_bucket",
+            },
+            "endpoint": {
+                "from_secret": "cache_public_s3_server",
+            },
+            "path_style": True,
+            "source": "test-results/**/*",
+            "strip_prefix": "test-results",
+            "target": "/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/tracing",
+        },
+        "environment": {
+            "AWS_ACCESS_KEY_ID": {
+                "from_secret": "cache_public_s3_access_key",
+            },
+            "AWS_SECRET_ACCESS_KEY": {
+                "from_secret": "cache_public_s3_secret_key",
+            },
+        },
+        "when": {
+            "status": ["failure"],
+        },
+    }]
+
+def logTracingResult(ctx):
+    return [{
+        "name": "log-tracing-result",
+        "image": OC_UBUNTU,
+        "commands": [
+            "cd test-results/",
+            'echo "To see the trace, please open the following link in the console"',
+            'for f in */; do echo "npx playwright show-trace https://cache.owncloud.com/public/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/tracing/$f"trace.zip" \n"; done',
+        ],
+        "when": {
+            "status": ["failure"],
+        },
+    }]
+
+def e2eTests(ctx):
+    e2e_test_steps = []
+
+    for app in APPS_COVERED_E2E:
+        e2e_test_steps.append({
+            "name": app,
+            "image": OC_CI_NODEJS,
+            "commands": [
+                "pnpm exec playwright install chromium",
+                "BASE_URL_OCIS=https://ocis:9200 pnpm test:e2e --project='%s-chromium'" % app,
+            ],
+        })
+
+    return [{
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "e2e-tests",
+        "steps": installPnpm() + ocisService() + e2e_test_steps + uploadTracingResult(ctx) + logTracingResult(ctx),
+        "trigger": {
+            "ref": [
+                "refs/heads/main",
+                "refs/heads/stable-*",
+                "refs/tags/**",
+                "refs/pull/**",
+            ],
+        },
+        "volumes": [
+            {
+                "name": "apps",
+                "temp": {},
+            },
+        ],
+    }]
+
+volumes = [
+    {
+        "name": "apps",
+        "path": "/apps",
+    },
+]

--- a/.drone.star
+++ b/.drone.star
@@ -335,7 +335,7 @@ def ocisService():
 
     app_build_steps = [
         {
-            "name": "build-web",
+            "name": "build-web-apps",
             "image": OC_CI_NODEJS,
             "commands": [
                 "pnpm build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/support/drone/ocis.web.config.json
+++ b/support/drone/ocis.web.config.json
@@ -1,0 +1,18 @@
+{
+  "server": "https://ocis:9200",
+  "theme": "https://ocis:9200/themes/owncloud/theme.json",
+  "openIdConnect": {
+    "metadata_url": "https://ocis:9200/.well-known/openid-configuration",
+    "authority": "https://ocis:9200",
+    "client_id": "web",
+    "response_type": "code"
+  },
+  "apps": [
+    "files",
+    "text-editor",
+    "pdf-viewer",
+    "search",
+    "external",
+    "admin-settings"
+  ]
+}


### PR DESCRIPTION
- [x] example test for creating draw-io file
- [x] put e2e tests to CI
- [x] add tracing in the CI. example: https://drone.owncloud.com/owncloud/web-extensions/688/4/8 Failed test restarted once with recording trace