### PR TITLE
ci: paste release notes directly and add variables

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -228,7 +228,11 @@ def publishSteps(ctx):
                 "sha256",
             ],
             "title": "%s %s" % (app, version),
-            "note": ".release_note",
+            "note": """%s-%s
+
+              ## How to use
+              Download the attached release artifact "%s-%s.zip" and extract it to your oCIS apps folder.
+              Please refer to [our documentation](https://owncloud.dev/services/web/#loading-applications) for more information.""" % (app, version, app, version),
             "overwrite": True,
         },
         "when": {

--- a/.release_note
+++ b/.release_note
@@ -1,5 +1,0 @@
-{{ .Product }}-{{ .Version }}
-
-## How to use
-Download the attached release artifact "{{ .Product }}-{{ .Version }}.zip" and extract it to your oCIS apps folder.
-Please refer to [our documentation](https://owncloud.dev/services/web/#loading-applications) for more information.


### PR DESCRIPTION
## Summary

It seems like the template variables are not supported by the plugin. Pasting the notes directly while providing the variables and replacing the values in the notes should fix the releases.

## Related issues

- resolves https://github.com/owncloud/web-extensions/issues/124

