### PR TITLE
ci: drop release notes leading whitespace

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -237,9 +237,9 @@ def publishSteps(ctx):
             "title": "%s %s" % (app, version),
             "note": """%s-%s
 
-              ## How to use
-              Download the attached release artifact "%s-%s.zip" and extract it to your oCIS apps folder.
-              Please refer to [our documentation](https://owncloud.dev/services/web/#loading-applications) for more information.""" % (app, version, app, version),
+## How to use
+Download the attached release artifact "%s-%s.zip" and extract it to your oCIS apps folder.
+Please refer to [our documentation](https://owncloud.dev/services/web/#loading-applications) for more information.""" % (app, version, app, version),
             "overwrite": True,
         },
         "when": {


### PR DESCRIPTION
When the release notes are inserted into the GitHub release, they are inserted with leading whitespace on every line. To correctly format the notes, drop the whitespace.