### PR TITLE
bugfix: Incomplete URL substring sanitization

### DIFF
--- a/packages/web-app-draw-io/tests/unit/App.spec.ts
+++ b/packages/web-app-draw-io/tests/unit/App.spec.ts
@@ -8,7 +8,8 @@ describe('Draw.io app', () => {
   it('uses the url from the app config as base iFrame url', () => {
     const url = 'https://foo.bar'
     const { wrapper } = createWrapper({ url })
-    expect(wrapper.find('iFrame').attributes('src').startsWith(url)).toBeTruthy()
+    const src = wrapper.find('iFrame').attributes('src');
+    expect(new URL(src).host).toBe(new URL(url).host);
   })
 })
 

--- a/packages/web-app-external-sites/tests/unit/App.spec.ts
+++ b/packages/web-app-external-sites/tests/unit/App.spec.ts
@@ -8,7 +8,7 @@ describe('external sites app', () => {
     const { wrapper } = createWrapper({ name, url })
 
     expect(wrapper.find('iFrame').attributes('title')).equal(name)
-    expect(wrapper.find('iFrame').attributes('src').startsWith(url)).toBeTruthy()
+    expect(new URL(wrapper.find('iFrame').attributes('src')).host).toEqual(new URL(url).host)
   })
 })
 


### PR DESCRIPTION
fix the problem, the packages should parse the `src` attribute of the iframe as a URL and check that its host matches the expected host (`foo.bar`). This avoids the incomplete substring check and ensures that the iframe is only pointed at the intended host. The best way to do this in TypeScript is to use the standard `URL` class to parse the URL and compare the `host` property. The change should be made in the test assertion on line 11 of `packages/web-app-draw-io/tests/unit/App.spec.ts`. No additional dependencies are required, as the `URL` class is available in modern JavaScript/TypeScript environments.
