### PR TITLE
chore: add oC Web monorepo package group

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,6 +1,18 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>owncloud-ops/renovate-presets:docker"],
-    "prConcurrentLimit": 15,
-    "postUpdateOptions": ["pnpmDedupe"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>owncloud-ops/renovate-presets:docker"],
+  "prConcurrentLimit": 15,
+  "postUpdateOptions": ["pnpmDedupe"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "@ownclouders/extension-sdk",
+        "@ownclouders/web-test-helpers",
+        "@ownclouders/web-client",
+        "@ownclouders/web-pkg",
+        "@ownclouders/eslint-config"
+      ],
+      "groupName": "ownCloud Web monorepo"
+    }
+  ]
 }


### PR DESCRIPTION
Added ownCloud Web monorepo packages into custom package group in Renovate configuration. This should handle all future updates of these packages within a single PR.