### PR TITLE
Update nodejs from v20 to v24

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,7 @@
 MINIO_MC = "minio/mc:RELEASE.2025-04-16T18-13-26Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
-OC_CI_NODEJS = "owncloudci/nodejs:22"
+OC_CI_NODEJS = "owncloudci/nodejs:24"
 OC_UBUNTU = "owncloud/ubuntu:20.04"
 PLUGINS_DOCKER = "plugins/docker:20.14"
 PLUGINS_GITHUB_RELEASE = "plugins/github-release:1"


### PR DESCRIPTION
This PR updates nodejs from v20 to ~v22~ v24.

**Background:**
CI messages in e2e tests, build web apps:
"You are using Node.js 20.17.0. Vite requires Node.js version 20.19+ or 22.12+. Please upgrade your Node.js version."
Updating [owncloudci](https://github.com/owncloud-ci/nodejs/pull/144) fails because signatures cant be found. Therefore trying to update node itself to the next version.