### PR TITLE
fix(draw-io): make applicationConfig prop optional

### DIFF
--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -33,8 +33,7 @@ export default defineComponent({
     },
     applicationConfig: {
       type: Object as PropType<AppConfigObject>,
-      required: true,
-      // hack so the correct type is being used for the app config
+      required: false,
       default: (): AppConfigObject => undefined
     },
     currentContent: {


### PR DESCRIPTION
## Summary
- Fix `vue/no-required-prop-with-default` linter warning in `packages/web-app-draw-io/src/App.vue`
- The `applicationConfig` prop has a default value, so it should not be marked as `required`

## Test plan
- [ ] Verify `pnpm lint` no longer reports the warning
- [ ] Verify draw-io extension still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)