### PR TITLE
fix(draw-io): make applicationConfig prop optional to fix lint warning

### DIFF
--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -33,8 +33,7 @@ export default defineComponent({
     },
     applicationConfig: {
       type: Object as PropType<AppConfigObject>,
-      required: true,
-      // hack so the correct type is being used for the app config
+      required: false,
       default: (): AppConfigObject => undefined
     },
     currentContent: {


### PR DESCRIPTION
References: #322 (fix(draw-io): make applicationConfig prop optional)

The prop has a default value, so it should not be marked as required. Fixes: vue/no-required-prop-with-default

@LukasHirt pls double check if this fixes the issue correctly

Attempt to fix the linter warning:

```
+ pnpm lint

> web-extensions@ lint /drone/src
> eslint '{packages,support}/**/*.{js,ts,vue}' '*.{ts,js}' --color


/drone/src/packages/web-app-draw-io/src/App.vue
  34:5  warning  Prop "applicationConfig" should be optional  vue/no-required-prop-with-default

✖ 1 problem (0 errors, 1 warning)
```
