### PR TITLE
fix(photo-addon): add referrer policy for OSM map tiles

### DIFF
--- a/packages/web-app-photo-addon/src/components/PhotoMap.vue
+++ b/packages/web-app-photo-addon/src/components/PhotoMap.vue
@@ -473,8 +473,36 @@ function initMap() {
     prefetchVisibleClusters()
   })
 
-  // Add OpenStreetMap tile layer (noWrap prevents world map repeating)
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  // OSM tile servers require a Referer header. Ensure referrer policy allows it.
+  let metaReferrer = document.querySelector('meta[name="referrer"]') as HTMLMetaElement | null
+  if (!metaReferrer) {
+    metaReferrer = document.createElement('meta')
+    metaReferrer.name = 'referrer'
+    metaReferrer.content = 'no-referrer-when-downgrade'
+    document.head.appendChild(metaReferrer)
+  } else if (metaReferrer.content === 'no-referrer' || metaReferrer.content === 'same-origin') {
+    // Temporarily relax for OSM tiles — restored on unmount
+    metaReferrer.dataset.originalContent = metaReferrer.content
+    metaReferrer.content = 'no-referrer-when-downgrade'
+  }
+
+  // Tile layer with retry on 403 (transient referrer issues)
+  const OsmTileLayer = L.TileLayer.extend({
+    createTile(coords: any, done: any) {
+      const tile = L.TileLayer.prototype.createTile.call(this, coords, done) as HTMLImageElement
+      tile.referrerPolicy = 'no-referrer-when-downgrade'
+      const originalSrc = tile.src
+      tile.addEventListener('error', () => {
+        // Retry once after a short delay
+        if (!tile.dataset.retried) {
+          tile.dataset.retried = '1'
+          setTimeout(() => { tile.src = originalSrc }, 500)
+        }
+      }, { once: false })
+      return tile
+    }
+  })
+  new OsmTileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     maxZoom: 19,
     keepBuffer: 2,
@@ -779,6 +807,12 @@ onUnmounted(() => {
   if (activeTooltip) {
     activeTooltip.remove()
     activeTooltip = null
+  }
+  // Restore original referrer policy if we changed it
+  const metaRef = document.querySelector('meta[name="referrer"]') as HTMLMetaElement | null
+  if (metaRef?.dataset.originalContent) {
+    metaRef.content = metaRef.dataset.originalContent
+    delete metaRef.dataset.originalContent
   }
   // Clean up injected CSS (only if no other PhotoMap instances)
   // Note: We leave the CSS in place since it's idempotent and shared

--- a/packages/web-app-photo-addon/src/components/PhotoMap.vue
+++ b/packages/web-app-photo-addon/src/components/PhotoMap.vue
@@ -486,28 +486,27 @@ function initMap() {
     metaReferrer.content = 'no-referrer-when-downgrade'
   }
 
-  // Tile layer with retry on 403 (transient referrer issues)
-  const OsmTileLayer = L.TileLayer.extend({
-    createTile(coords: any, done: any) {
-      const tile = L.TileLayer.prototype.createTile.call(this, coords, done) as HTMLImageElement
-      tile.referrerPolicy = 'no-referrer-when-downgrade'
-      const originalSrc = tile.src
-      tile.addEventListener('error', () => {
-        // Retry once after a short delay
-        if (!tile.dataset.retried) {
-          tile.dataset.retried = '1'
-          setTimeout(() => { tile.src = originalSrc }, 500)
-        }
-      }, { once: false })
-      return tile
-    }
-  })
-  new OsmTileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  // Tile layer with referrer policy fix and retry on 403
+  const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     maxZoom: 19,
     keepBuffer: 2,
     noWrap: true,
   }).addTo(map)
+
+  // Set referrer policy on each tile and retry on failure
+  tileLayer.on('tileloadstart', (event: L.TileEvent) => {
+    const tile = event.tile as HTMLImageElement
+    tile.referrerPolicy = 'no-referrer-when-downgrade'
+  })
+  tileLayer.on('tileerror', (event: L.TileErrorEvent) => {
+    const tile = event.tile as HTMLImageElement
+    if (!tile.dataset.retried) {
+      tile.dataset.retried = '1'
+      const src = tile.src
+      setTimeout(() => { tile.src = src }, 500)
+    }
+  })
 
   // Add photo markers
   addPhotoMarkers()


### PR DESCRIPTION
## Summary
- OSM tile servers require a `Referer` header, but oCIS may set a strict `Referrer-Policy` that strips it
- Injects `<meta name="referrer" content="no-referrer-when-downgrade">` when the map initializes (restored on unmount)
- Sets `referrerPolicy` on each tile `<img>` element via custom TileLayer
- Failed tiles automatically retry once after 500ms

## Test plan
- [ ] Open map view — verify no 403 errors on OSM tiles
- [ ] Pan and zoom the map — verify all tiles load correctly
- [ ] Switch away from map view and back — verify tiles still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)