### PR TITLE
chore: change translation sync schedule to daily and restrict permissions

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -2,8 +2,10 @@ name: Translation Sync
 
 on:
   schedule:
-    - cron: '0 2 * * 1'
+    - cron: '0 2 * * *'
   workflow_dispatch:
+
+permissions: {}
 
 jobs:
   sync:


### PR DESCRIPTION
- Change schedule from weekly (`0 2 * * 1`) to daily (`0 2 * * *`)
- Add `permissions: {}` to restrict `GITHUB_TOKEN` to no permissions (CodeQL finding)