### PR TITLE
feat: allow manual trigger in release.yml (GHA)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*-v*'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
When the trigger is not started automatically on new tags, we should allow to trigger it at least manually.