### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,131 @@
-# web-extensions
+# Web Extensions
 
-[![Matrix](https://img.shields.io/matrix/ocis%3Amatrix.org?logo=matrix)](https://app.element.io/#/room/#ocis:matrix.org)
-[![Test](https://github.com/owncloud/web-extensions/actions/workflows/test.yml/badge.svg)](https://github.com/owncloud/web-extensions/actions/workflows/test.yml)
-[![web-extensions docker image](https://img.shields.io/docker/v/owncloud/web-extensions?label=web-extensions&logo=docker&sort=semver)](https://hub.docker.com/r/owncloud/web-extensions)
-[![License](https://img.shields.io/badge/License-AGPL%203-blue.svg)](https://opensource.org/licenses/AGPL-3.0)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-This repository contains a collection of [ownCloud Web](https://github.com/owncloud/web) extensions that, for various reasons, have not been added to the main repository.
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/web-extensions)
 
-   * [Existing Web-Extensions](#existing-web-extensions)
-   * [Installing Apps in oCIS](#installing-apps-in-ocis)
-   * [Adding a New App to This Repository](#adding-a-new-app-to-this-repository)
-   * [Release Workflow for Web Extensions](#release-workflow-for-web-extensions)
+Web Extensions is a collection of community and supplementary extensions for the ownCloud Web frontend that, for various reasons, are maintained outside of the main web repository. It includes extensions for draw.io integration, JSON file viewing, file casting, advanced search, photo enhancements, file importing, progress bars, external sites embedding and file unzipping -- each deployable as a standalone web app within oCIS.
 
-<!-- Created by https://github.com/ekalinin/github-markdown-toc -->
+## Part of oCIS
 
-## Existing Web-Extensions
+This repository is part of the [ownCloud Infinite Scale (oCIS)](https://github.com/owncloud/ocis) ecosystem. The extensions integrate with the [ownCloud Web](https://github.com/owncloud/web) frontend and can be individually enabled in oCIS deployments.
 
-The following extension examples are provided to be used with the Infinite Scale web frontend.
+Web Extensions are available on [Docker Hub](https://hub.docker.com/r/owncloud/web-extensions).
 
-- [web-app-advanced-search](./packages/web-app-advanced-search/)
-- [web-app-cast](./packages/web-app-cast/)
-- [web-app-draw-io](./packages/web-app-draw-io/)
-- [web-app-external-sites](./packages/web-app-external-sites/)
-- [web-app-importer](./packages/web-app-importer/)
-- [web-app-json-viewer](./packages/web-app-json-viewer/)
-- [web-app-photo-addon](./packages/web-app-photo-addon/)
-- [web-app-progress-bars](./packages/web-app-progress-bars/)
-- [web-app-unzip](./packages/web-app-unzip/)
+### Included Extensions
 
-## Installing Apps in oCIS
+- [web-app-advanced-search](packages/web-app-advanced-search/) -- Advanced search capabilities
+- [web-app-cast](packages/web-app-cast/) -- Cast files to external devices
+- [web-app-draw-io](packages/web-app-draw-io/) -- Draw.io diagram integration
+- [web-app-external-sites](packages/web-app-external-sites/) -- Embed external websites
+- [web-app-importer](packages/web-app-importer/) -- File import functionality
+- [web-app-json-viewer](packages/web-app-json-viewer/) -- JSON file viewer
+- [web-app-photo-addon](packages/web-app-photo-addon/) -- Photo enhancement features
+- [web-app-progress-bars](packages/web-app-progress-bars/) -- Upload/download progress bars
+- [web-app-unzip](packages/web-app-unzip/) -- ZIP file extraction
 
-There are two ways installing these extension examples:
+## Getting Started
 
-* You can enable the web apps in our deployment example with minimal effort.\
-  To see how this gets implemented, see the [ocis_full](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_full) deployment example.\
-  For a detailed installation instruction using `ocis_full` see the [admin docs, Local Production Setup](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html).\
-  (Before you start, select the ocis version in the admin docs you want to use this example for.)
-* On a general level, refer to the [Web app docs](https://owncloud.dev/services/web/#loading-applications) to learn how to install apps in oCIS.
+Follow the steps below to install and develop extensions.
 
-## Adding a New App to This Repository
+### Installation (oCIS Deployment Example)
 
-To start developing a new web-extension or maintaining an existing one, see the [Starting Guide](docs/starting_guide.md) for more details.
+Extensions can be enabled in the [ocis_full deployment example](https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_full) with minimal configuration. See the [admin docs](https://doc.owncloud.com/ocis/next/depl-examples/ubuntu-compose/ubuntu-compose-prod.html) for detailed instructions.
 
-## Release Workflow for Web Extensions
+### Manual Installation
 
-If required, an own document guides you through processing new releases of apps, such as when code changes have been made or dependencies have been updated. For more details see the [RELEASE_WORKFLOW](./docs/RELEASE_WORKFLOW.md) documentation.
+Refer to the [Web app docs](https://owncloud.dev/services/web/#loading-applications) to learn how to install apps in oCIS.
 
+### Development
+
+For developing new extensions or maintaining existing ones, see the [Starting Guide](docs/starting_guide.md).
+
+```bash
+pnpm install               # Install dependencies
+pnpm build                 # Build all extensions
+```
+
+## Documentation
+
+- [Starting Guide](docs/starting_guide.md)
+- [Release Workflow](docs/RELEASE_WORKFLOW.md)
+- [ownCloud Web Extension System](https://owncloud.dev/clients/web/extension-system/)
+- [Loading Applications in oCIS](https://owncloud.dev/services/web/#loading-applications)
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/web-extensions)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud-web/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [AGPL-3.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: AGPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All AGPL/GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: AGPL-3.0 is a strong copyleft license; migration requires full relicensing of all files, not just a header change

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,88 @@
+# agents.md — web-extensions
+
+## Repository Overview
+
+A collection of supplementary ownCloud Web extensions maintained outside the main web repository. Includes extensions for draw.io, JSON viewing, file casting, advanced search, photo enhancements, file importing, progress bars, external sites and ZIP extraction.
+
+- **Classification:** oCIS
+- **Activity Status:** Active
+- **License:** AGPL-3.0
+- **Language:** Vue.js, TypeScript
+
+## Architecture & Key Paths
+
+- `packages/` — Monorepo containing individual extensions:
+  - `packages/web-app-advanced-search/` — Advanced search extension
+  - `packages/web-app-cast/` — File casting extension
+  - `packages/web-app-draw-io/` — Draw.io diagram integration
+  - `packages/web-app-external-sites/` — External site embedding
+  - `packages/web-app-importer/` — File import extension
+  - `packages/web-app-json-viewer/` — JSON file viewer
+  - `packages/web-app-photo-addon/` — Photo enhancement features
+  - `packages/web-app-progress-bars/` — Progress bar extension
+  - `packages/web-app-unzip/` — ZIP extraction extension
+- `docs/` — Documentation (starting guide, release workflow)
+- `docker/` — Docker build files
+- `dev/` — Development environment configuration
+- `support/` — Support scripts
+- `Makefile` — Build orchestration
+- `package.json` — Root package with scripts
+- `pnpm-workspace.yaml` — pnpm monorepo workspace configuration
+- `playwright.config.ts` — Playwright e2e test configuration
+- `eslint.config.js` — ESLint configuration
+
+## Development Conventions
+
+- pnpm monorepo with workspace packages
+- Prettier for code formatting
+- Vite for building individual extensions
+- Playwright for e2e testing
+- GitHub Actions CI
+- Each extension is independently versioned and releasable
+- Release workflow documented in `docs/RELEASE_WORKFLOW.md`
+
+## Build & Test Commands
+
+```bash
+pnpm install                # Install dependencies
+pnpm build                  # Build all extensions
+pnpm test:unit               # Run unit tests
+pnpm test:e2e                # Run E2E tests
+pnpm lint                   # Run ESLint
+```
+
+## Important Constraints
+
+- **AGPL-3.0 copyleft license:** The OSPO Apache 2.0 migration requires auditing this copyleft license.
+- **Monorepo structure:** Each extension in `packages/` can be built and released independently.
+- **oCIS dependency:** Extensions require oCIS and ownCloud Web to function.
+- **Docker image:** Published as `owncloud/web-extensions` on Docker Hub.
+- **External dependencies:** Some extensions (draw.io, external sites) embed or connect to third-party services.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+- This is a pnpm monorepo containing multiple independent web extensions.
+- Each extension in `packages/` has its own `package.json`, source code and build config.
+- The `docs/starting_guide.md` explains how to add new extensions to the repository.
+- Docker images bundle all extensions together for deployment.
+- Extensions register with the oCIS Web runtime via the extension system API.
+- Development environment uses Docker Compose with an oCIS backend.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>