### PR TITLE
fix(photo-addon): harden e2e fixtures against intermittent failures

### DIFF
--- a/packages/web-app-photo-addon/tests/e2e/fixtures.ts
+++ b/packages/web-app-photo-addon/tests/e2e/fixtures.ts
@@ -50,10 +50,12 @@ export async function navigateToPhotoView(page: Page): Promise<void> {
   await appSwitcher.waitFor({ state: 'visible', timeout: 30000 })
   await appSwitcher.click()
 
-  // Find and click the Photos app
-  const photoApp = page.locator('text=Photos')
-  await photoApp.waitFor({ state: 'visible', timeout: 10000 })
-  await photoApp.click()
+  // Find and click the Photos app. Use an exact text match so we don't accidentally
+  // pick up the photo app's own header (e.g. "Photos (123)") if it's already mounted
+  // from a prior test.
+  const photoApp = page.getByText('Photos', { exact: true })
+  await photoApp.first().waitFor({ state: 'visible', timeout: 10000 })
+  await photoApp.first().click()
 
   // Wait for the photo view to load
   await page.waitForLoadState('domcontentloaded')
@@ -63,23 +65,25 @@ export async function navigateToPhotoView(page: Page): Promise<void> {
  * Wait for photos to be loaded in the gallery view
  */
 export async function waitForPhotosLoaded(page: Page): Promise<void> {
-  // Wait for either photos to appear or the empty state
-  const photoGrid = page.locator('.photo-grid')
-  const emptyState = page.locator('.no-photos, .empty-state')
-  const loadingState = page.locator('.loading-spinner, .loading-state')
+  // Make sure we're actually on the photos view first.
+  await page.locator('.photos-app').waitFor({ state: 'visible', timeout: 30000 })
 
-  // Wait for loading to finish
-  await loadingState.waitFor({ state: 'hidden', timeout: 60000 }).catch(() => {
-    // Loading state might not be visible if photos load quickly
-  })
+  // Wait for the loading indicator to clear if present. The real selector lives in
+  // PhotosView.vue as `.loading-status`; the previous `.loading-spinner` never matched.
+  const loadingStatus = page.locator('.photos-app .loading-status')
+  if (await loadingStatus.isVisible().catch(() => false)) {
+    await loadingStatus.waitFor({ state: 'hidden', timeout: 60000 })
+  }
 
-  // Either photos or empty state should be visible
-  await Promise.race([
+  // After loading, the view shows either a populated photo grid or the empty state.
+  // Use Promise.any so the first to appear wins, and don't swallow failures — if
+  // neither shows up the test should fail here with a clear cause.
+  const photoGrid = page.locator('.photo-grid').first()
+  const emptyState = page.locator('.empty-state, .no-photos').first()
+  await Promise.any([
     photoGrid.waitFor({ state: 'visible', timeout: 30000 }),
     emptyState.waitFor({ state: 'visible', timeout: 30000 })
-  ]).catch(() => {
-    // Continue even if neither is visible - test will fail with better error
-  })
+  ])
 }
 
 /**


### PR DESCRIPTION
## Summary

Hardens the photo-addon e2e test fixtures (`fixtures.ts`) against three real flake sources that surfaced after the Drone → GitHub Actions migration. Martin reported the `lightbox.spec.ts:14` test (`should open lightbox when clicking a photo`) failing intermittently — the referenced run (`26073748028`) has expired logs/artifacts, so the diagnosis here is based on reading the fixture + view code rather than the actual stack trace.

CI runs against a freshly-launched oCIS Docker with no seeded photos, so most test bodies short-circuit through `if (count > 0)`. That means an actual failure must be raised by the navigation / wait helpers themselves — exactly the code being hardened.

Three targeted fixes:

- **Exact match for the Photos app switcher item.** `text=Photos` is a partial-text matcher and also matches the photo app's own `<h1>Photos (123)</h1>` header if it's still in the DOM from a previous test. Replaced with `getByText('Photos', { exact: true })`.
- **No more silently-swallowed timeouts.** `waitForPhotosLoaded` had two `.catch(() => {})` blocks that hid genuine timeouts and let the test continue blind. Removed both, so the next failure points at the real cause instead of an opaque downstream error.
- **The loading-status selector now actually matches.** The previous `.loading-spinner, .loading-state` selectors never matched anything in `PhotosView.vue` — the indicator is rendered as `.loading-status`. Replaced and scoped under `.photos-app` to avoid colliding with other oCIS spinners.

`Promise.race(...).catch()` also became `Promise.any(...)` so the first fulfilment wins while real failures still surface.

## Test plan

- [x] `pnpm --filter ./packages/web-app-photo-addon check:types` — clean
- [x] `pnpm lint` — clean (one pre-existing draw-io warning, unrelated)
- [x] `pnpm --filter ./packages/web-app-photo-addon test:unit` — 48/48 pass
- [ ] CI e2e (`pnpm --filter ./packages/web-app-photo-addon test:e2e --project='chrome'`) — needs a running oCIS, cannot run locally; will be exercised by this PR's CI run
- [ ] Confirm whether the next failing run produces a more actionable error message than "Process completed with exit code 1"

🤖 Generated with [Claude Code](https://claude.com/claude-code)