### PR TITLE
feat(web-app-version-changelog): add version changelog sidebar panel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
           - web-app-ai-doc-summary
           - web-app-chat-with-file
           - ai-llm-proxy
+          - web-app-version-changelog
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Web Extensions are available on [Docker Hub](https://hub.docker.com/r/owncloud/w
 - [web-app-photo-addon](packages/web-app-photo-addon/) -- Photo enhancement features
 - [web-app-progress-bars](packages/web-app-progress-bars/) -- Upload/download progress bars
 - [web-app-unzip](packages/web-app-unzip/) -- ZIP file extraction
+- [web-app-version-changelog](packages/web-app-version-changelog/) -- AI-generated changelog summaries for file version history
 
 ## Getting Started
 

--- a/dev/docker/ocis.apps.yaml
+++ b/dev/docker/ocis.apps.yaml
@@ -13,3 +13,9 @@ chat-with-file:
     llm:
       endpoint: 'https://host.docker.internal:9200/ai-llm-proxy/v1'
       model: 'llama3.2'
+
+version-changelog:
+  config:
+    llm:
+      endpoint: 'https://host.docker.internal:9200/ai-llm-proxy/v1'
+      model: 'llama3.2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - ./packages/web-app-unzip/dist:/web/apps/unzip
       - ./packages/web-app-ai-doc-summary/dist:/web/apps/ai-doc-summary
       - ./packages/web-app-chat-with-file/dist:/web/apps/chat-with-file
+      - ./packages/web-app-version-changelog/dist:/web/apps/version-changelog
     depends_on:
       - traefik
 

--- a/packages/web-app-version-changelog/LICENSE
+++ b/packages/web-app-version-changelog/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 ownCloud GmbH
+   
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/web-app-version-changelog/README.md
+++ b/packages/web-app-version-changelog/README.md
@@ -23,19 +23,17 @@ to produce a concise description of what changed.
 Add an `llm` block to your oCIS web configuration:
 
 ```yaml
-web:
+version-changelog:
   config:
-    options:
-      apps:
-        - web-app-version-changelog
-      llm:
-        endpoint: "https://your-ocis.example.com/ai-llm-proxy/v1"
-        model: "llama3.1:70b"
+    llm:
+      endpoint: "https://your-ocis.example.com/ai-llm-proxy/v1"
+      model: "llama3.1:70b"
 ```
 
 The endpoint must be OpenAI-compatible (`POST /chat/completions`). The Bearer token from the
 current user session is forwarded as the `Authorization` header, so endpoint-level auth is
-handled by the proxy you configure in oCIS.
+handled by the proxy you configure in oCIS. The endpoint must be same-origin — cross-origin
+endpoints are rejected at startup to prevent session token exfiltration.
 
 ## Known Limitations (v1)
 

--- a/packages/web-app-version-changelog/README.md
+++ b/packages/web-app-version-changelog/README.md
@@ -1,0 +1,67 @@
+# AI Version Changelog Sidebar
+
+[![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+
+An ownCloud Infinite Scale (oCIS) sidebar panel extension that generates human-readable changelog
+entries for each file version. When a user selects a file with version history, the "Changelog"
+panel appears alongside the standard file history. Each version row has a **Generate** button
+that diffs the two version blobs on-demand and sends the diff to a configured BYO-LLM endpoint
+to produce a concise description of what changed.
+
+## Features
+
+- On-demand changelog generation per version pair (no backend service required)
+- LLM output is a short casual prose summary ("Added the budget forecast for Q3…"), rendered in the user's UI language
+- Session-scoped cache — the same version pair is never sent to the LLM twice
+- Per-row error state with Retry button
+- Graceful degradation when no LLM endpoint is configured (version list still visible, Generate button disabled)
+- Binary file detection — shows a clear message instead of sending binary diffs
+- Registered on the `global.files.sidebar` extension point
+
+## Configuration
+
+Add an `llm` block to your oCIS web configuration:
+
+```yaml
+web:
+  config:
+    options:
+      apps:
+        - web-app-version-changelog
+      llm:
+        endpoint: "https://your-ocis.example.com/ai-llm-proxy/v1"
+        model: "llama3.1:70b"
+```
+
+The endpoint must be OpenAI-compatible (`POST /chat/completions`). The Bearer token from the
+current user session is forwarded as the `Authorization` header, so endpoint-level auth is
+handled by the proxy you configure in oCIS.
+
+## Known Limitations (v1)
+
+- Text-based files only (`.txt`, `.md`, etc.). Binary files (images, Office documents, PDFs)
+  show a "Binary files are not supported" notice — no diff is generated.
+- The diff is truncated to 8 000 characters before being sent to the LLM; very large version
+  diffs will be summarised from a partial view of the changes.
+
+## Development
+
+```bash
+# Install dependencies (from repo root)
+pnpm install
+
+# Build the extension
+pnpm -F web-app-version-changelog build
+
+# Type check
+pnpm -F web-app-version-changelog check:types
+
+# Unit tests
+pnpm -F web-app-version-changelog test:unit
+
+# E2E tests (requires a running OCIS instance — see root README for setup)
+pnpm -F web-app-version-changelog test:e2e
+```
+
+See the root `README.md` for how to run a local OCIS development environment with the extension
+loaded.

--- a/packages/web-app-version-changelog/l10n/translations.json
+++ b/packages/web-app-version-changelog/l10n/translations.json
@@ -1,0 +1,3 @@
+{
+  "translations": {}
+}

--- a/packages/web-app-version-changelog/package.json
+++ b/packages/web-app-version-changelog/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "web-app-version-changelog",
+  "version": "0.2.0",
+  "description": "AI Version Changelog Sidebar - sidebarPanel extension for human-readable file version diffs",
+  "license": "Apache-2.0",
+  "author": "ownCloud",
+  "type": "module",
+  "scripts": {
+    "build": "pnpm vite build",
+    "build:w": "pnpm vite build --watch --mode development",
+    "check:types": "vue-tsc --noEmit",
+    "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest",
+    "test:e2e": "pnpm playwright test"
+  },
+  "dependencies": {
+    "@ownclouders/web-client": "^12.3.2",
+    "@ownclouders/web-pkg": "^12.3.2"
+  },
+  "devDependencies": {
+    "@ownclouders/extension-sdk": "12.3.2",
+    "@ownclouders/tsconfig": "0.0.6",
+    "@types/node": "22.19.19",
+    "@vue/test-utils": "^2.4.6",
+    "eslint": "9.39.4",
+    "happy-dom": "^20.9.0",
+    "prettier": "3.8.3",
+    "ts-node": "^10.9.2",
+    "typescript": "5.9.3",
+    "vite": "7.2.2",
+    "vitest": "4.1.7",
+    "vue": "^3.4.21",
+    "vue-router": "^5.0.7",
+    "vue-tsc": "3.3.2",
+    "vue3-gettext": "^2.4.0"
+  }
+}

--- a/packages/web-app-version-changelog/package.json
+++ b/packages/web-app-version-changelog/package.json
@@ -9,7 +9,7 @@
     "build": "pnpm vite build",
     "build:w": "pnpm vite build --watch --mode development",
     "check:types": "vue-tsc --noEmit",
-    "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest",
+    "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest run",
     "test:e2e": "pnpm playwright test"
   },
   "dependencies": {
@@ -24,7 +24,6 @@
     "eslint": "9.39.4",
     "happy-dom": "^20.9.0",
     "prettier": "3.8.3",
-    "ts-node": "^10.9.2",
     "typescript": "5.9.3",
     "vite": "7.2.2",
     "vitest": "4.1.7",

--- a/packages/web-app-version-changelog/playwright.config.ts
+++ b/packages/web-app-version-changelog/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test'
+import baseConfig from '../../playwright.config'
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  ...baseConfig,
+  testDir: './tests/e2e'
+})

--- a/packages/web-app-version-changelog/public/manifest.json
+++ b/packages/web-app-version-changelog/public/manifest.json
@@ -1,0 +1,3 @@
+{
+  "entrypoint": "index.js"
+}

--- a/packages/web-app-version-changelog/src/components/ChangelogPanel.vue
+++ b/packages/web-app-version-changelog/src/components/ChangelogPanel.vue
@@ -1,0 +1,254 @@
+<template>
+  <div
+    data-testid="version-changelog-panel"
+    class="version-changelog-panel oc-background-muted oc-p-m oc-rounded"
+  >
+    <div v-if="!llmConfig" class="changelog-notice oc-mb-m" role="note">
+      {{ $gettext('Configure an AI endpoint in admin settings to generate changelogs.') }}
+    </div>
+
+    <div v-if="isBinaryFile" class="changelog-placeholder">
+      {{ $gettext('Binary files are not supported for changelog generation.') }}
+    </div>
+
+    <template v-else>
+      <div v-if="isLoading" class="changelog-placeholder">
+        {{ $gettext('Loading version history…') }}
+      </div>
+
+      <div v-else-if="historyError" class="changelog-error" role="alert">
+        {{ historyError }}
+      </div>
+
+      <div v-else-if="!versions.length" class="changelog-placeholder">
+        {{ $gettext('No version history available for this file.') }}
+      </div>
+
+      <template v-else>
+        <div
+          v-for="(version, index) in versions"
+          :key="version.id ?? index"
+          class="changelog-version-row oc-mb-s"
+          data-testid="version-row"
+        >
+          <div class="oc-flex oc-flex-between oc-flex-middle oc-mb-xs">
+            <div class="changelog-version-meta">
+              <span class="changelog-version-number oc-mr-xs">
+                {{ $gettext('v%{n}', { n: versions.length - index }) }}
+              </span>
+              <span class="changelog-version-date">
+                {{ formatDate(version.mdate) }}
+              </span>
+            </div>
+            <template v-if="llmConfig">
+              <span v-if="isGeneratingKey(cacheKey(index))" class="changelog-generating">
+                {{ $gettext('Generating…') }}
+              </span>
+              <oc-button
+                v-else-if="!getEntry(cacheKey(index))"
+                size="small"
+                :aria-label="$gettext('Generate changelog entry')"
+                @click="onGenerate(index)"
+              >
+                {{ $pgettext('Button to generate version changelog entry', 'Generate') }}
+              </oc-button>
+            </template>
+            <oc-button
+              v-else
+              size="small"
+              :disabled="true"
+              :aria-label="$gettext('Configure AI to generate changelog')"
+            >
+              {{ $pgettext('Button to generate version changelog entry', 'Generate') }}
+            </oc-button>
+          </div>
+
+          <div
+            v-if="getError(cacheKey(index))"
+            class="changelog-entry-error oc-mb-xs"
+            role="alert"
+          >
+            <span>{{ getError(cacheKey(index)) }}</span>
+            <oc-button
+              v-if="llmConfig"
+              size="small"
+              appearance="raw"
+              class="oc-ml-xs"
+              @click="onRetry(index)"
+            >
+              {{ $pgettext('Button to retry changelog generation', 'Retry') }}
+            </oc-button>
+          </div>
+
+          <p
+            v-if="getEntry(cacheKey(index))"
+            class="changelog-entry-plain oc-mt-xs"
+          >
+            {{ getEntry(cacheKey(index))!.summary }}
+          </p>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, watch } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { useClientService, useConfigStore, useSpacesStore } from '@ownclouders/web-pkg'
+import { useVersionHistory } from '../composables/useVersionHistory'
+import { useChangelog } from '../composables/useChangelog'
+import type { LlmConfig } from '../composables/useLlm'
+import type { Resource } from '@ownclouders/web-client'
+
+const TEXT_MIME_PREFIXES = ['text/', 'application/json', 'application/xml', 'application/xhtml']
+
+const { $gettext, $pgettext } = useGettext()
+
+const props = defineProps<{
+  resource?: Resource | null
+  llmConfig?: LlmConfig | null
+}>()
+
+const clientService = useClientService()
+const configStore = useConfigStore()
+const spacesStore = useSpacesStore()
+
+const { versions, isLoading, error: historyError, fetchVersions } = useVersionHistory()
+const llmConfigRef = computed(() => props.llmConfig ?? null)
+const { generateEntry, getEntry, isGeneratingKey, getError, clearError } = useChangelog(llmConfigRef)
+
+const isBinaryFile = computed(() => {
+  if (!props.resource) {
+    return false
+  }
+  const mime = props.resource.mimeType
+  if (!mime) {
+    return true
+  }
+  return !TEXT_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix))
+})
+
+function formatDate(mdate?: string): string {
+  if (!mdate) {
+    return $gettext('Unknown date')
+  }
+  const d = new Date(mdate)
+  if (isNaN(d.getTime())) {
+    return mdate
+  }
+  return d.toLocaleString()
+}
+
+function cacheKey(index: number): string {
+  const fileId = props.resource?.fileId ?? props.resource?.id ?? 'unknown'
+  const versionEtag = versions.value[index]?.etag || String(index)
+  return `${fileId}:${versionEtag}`
+}
+
+async function fetchVersionContent(versionIndex: number): Promise<string> {
+  const version = versions.value[versionIndex]
+  if (!version?.path) {
+    return ''
+  }
+  const serverUrl = configStore.serverUrl.replace(/\/$/, '')
+  const url = `${serverUrl}/dav${version.path}`
+  const response = await clientService.httpAuthenticated.get<string>(url, {
+    responseType: 'text'
+  })
+  return response.data ?? ''
+}
+
+async function fetchHeadContent(): Promise<string> {
+  const res = props.resource
+  if (!res?.fileId || !res?.storageId) {
+    return ''
+  }
+  const space = spacesStore.getSpace(res.storageId)
+  if (!space) {
+    return ''
+  }
+  const { response } = await clientService.webdav.getFileContents(
+    space,
+    { fileId: res.fileId },
+    { responseType: 'text' }
+  )
+  return (response.data as string) ?? ''
+}
+
+function makeFetchOld(index: number): () => Promise<string> {
+  return () => fetchVersionContent(index)
+}
+
+function makeFetchNew(index: number): () => Promise<string> {
+  if (index === 0) {
+    return fetchHeadContent
+  }
+  return () => fetchVersionContent(index - 1)
+}
+
+async function onGenerate(index: number): Promise<void> {
+  await generateEntry(cacheKey(index), makeFetchOld(index), makeFetchNew(index))
+}
+
+async function onRetry(index: number): Promise<void> {
+  clearError(cacheKey(index))
+  await generateEntry(cacheKey(index), makeFetchOld(index), makeFetchNew(index))
+}
+
+async function loadVersions(): Promise<void> {
+  if (!props.resource?.fileId) {
+    versions.value = []
+    return
+  }
+  await fetchVersions(props.resource.fileId)
+}
+
+onMounted(loadVersions)
+
+watch(
+  () => props.resource?.fileId,
+  () => loadVersions()
+)
+</script>
+
+<style scoped>
+.changelog-placeholder {
+  color: var(--oc-color-text-muted, #6f6f6f);
+  font-style: italic;
+}
+.changelog-error,
+.changelog-entry-error {
+  color: var(--oc-color-danger, #c00);
+  font-size: 0.9em;
+}
+.changelog-notice {
+  color: var(--oc-color-text-muted, #6f6f6f);
+  font-size: 0.9em;
+  border-left: 3px solid var(--oc-color-warning, #e6a817);
+  padding-left: 0.5em;
+}
+.changelog-version-row {
+  border-bottom: 1px solid var(--oc-color-border, #e0e0e0);
+  padding-bottom: 0.5em;
+}
+.changelog-version-row:last-child {
+  border-bottom: none;
+}
+.changelog-version-number {
+  font-weight: 600;
+}
+.changelog-version-date {
+  color: var(--oc-color-text-muted, #6f6f6f);
+  font-size: 0.85em;
+}
+.changelog-generating {
+  color: var(--oc-color-text-muted, #6f6f6f);
+  font-style: italic;
+  font-size: 0.9em;
+}
+.changelog-entry-plain {
+  color: var(--oc-color-text-default, #333);
+  font-size: 0.9em;
+}
+</style>

--- a/packages/web-app-version-changelog/src/components/ChangelogPanel.vue
+++ b/packages/web-app-version-changelog/src/components/ChangelogPanel.vue
@@ -41,7 +41,12 @@
               </span>
             </div>
             <template v-if="llmConfig">
-              <span v-if="isGeneratingKey(cacheKey(index))" class="changelog-generating">
+              <span
+                v-if="isGeneratingKey(cacheKey(index))"
+                class="changelog-generating"
+                role="status"
+                aria-live="polite"
+              >
                 {{ $gettext('Generating…') }}
               </span>
               <oc-button

--- a/packages/web-app-version-changelog/src/components/ChangelogPanel.vue
+++ b/packages/web-app-version-changelog/src/components/ChangelogPanel.vue
@@ -149,7 +149,7 @@ function cacheKey(index: number): string {
 async function fetchVersionContent(versionIndex: number): Promise<string> {
   const version = versions.value[versionIndex]
   if (!version?.path) {
-    return ''
+    throw new Error($gettext('Version content is unavailable.'))
   }
   const serverUrl = configStore.serverUrl.replace(/\/$/, '')
   const url = `${serverUrl}/dav${version.path}`
@@ -162,11 +162,11 @@ async function fetchVersionContent(versionIndex: number): Promise<string> {
 async function fetchHeadContent(): Promise<string> {
   const res = props.resource
   if (!res?.fileId || !res?.storageId) {
-    return ''
+    throw new Error($gettext('File information is unavailable.'))
   }
   const space = spacesStore.getSpace(res.storageId)
   if (!space) {
-    return ''
+    throw new Error($gettext('File storage space could not be found.'))
   }
   const { response } = await clientService.webdav.getFileContents(
     space,

--- a/packages/web-app-version-changelog/src/composables/useChangelog.ts
+++ b/packages/web-app-version-changelog/src/composables/useChangelog.ts
@@ -119,7 +119,9 @@ export function useChangelog(llmConfig: LlmConfig | null | Ref<LlmConfig | null>
     try {
       const [oldContent, newContent] = await Promise.all([fetchOld(), fetchNew()])
       const hunks = computeDiff(oldContent, newContent)
-      const diffText = diffToText(hunks).slice(0, MAX_DIFF_CHARS)
+      const raw = diffToText(hunks)
+      const diffText =
+        raw.length > MAX_DIFF_CHARS ? raw.slice(0, MAX_DIFF_CHARS) + '\n...[diff truncated]' : raw
 
       if (!diffText.trim()) {
         if (oldContent !== newContent) {

--- a/packages/web-app-version-changelog/src/composables/useChangelog.ts
+++ b/packages/web-app-version-changelog/src/composables/useChangelog.ts
@@ -99,8 +99,11 @@ export function useChangelog(llmConfig: LlmConfig | null | Ref<LlmConfig | null>
       throw new Error(aiErrorMessage(res.status))
     }
 
-    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> }
-    const text = data.choices?.[0]?.message?.content ?? ''
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string }; finish_reason?: string }>
+    }
+    const choice = data.choices?.[0]
+    const text = choice?.finish_reason === 'length' ? '' : (choice?.message?.content ?? '')
 
     return { summary: text.trim() || $gettext('No changes detected.') }
   }

--- a/packages/web-app-version-changelog/src/composables/useChangelog.ts
+++ b/packages/web-app-version-changelog/src/composables/useChangelog.ts
@@ -5,6 +5,7 @@ import { computeDiff, diffToText } from '../utils/diff'
 import type { LlmConfig } from './useLlm'
 
 const MAX_DIFF_CHARS = 8_000
+const MAX_CONTENT_CHARS = 500_000
 
 export interface ChangelogEntry {
   summary: string
@@ -118,6 +119,15 @@ export function useChangelog(llmConfig: LlmConfig | null | Ref<LlmConfig | null>
 
     try {
       const [oldContent, newContent] = await Promise.all([fetchOld(), fetchNew()])
+
+      if (oldContent.length > MAX_CONTENT_CHARS || newContent.length > MAX_CONTENT_CHARS) {
+        errors.value.set(
+          cacheKey,
+          $gettext('This file is too large to compare. Only files with up to 2,000 lines are supported.')
+        )
+        return
+      }
+
       const hunks = computeDiff(oldContent, newContent)
       const raw = diffToText(hunks)
       const diffText =

--- a/packages/web-app-version-changelog/src/composables/useChangelog.ts
+++ b/packages/web-app-version-changelog/src/composables/useChangelog.ts
@@ -1,0 +1,172 @@
+import { ref, isRef, type Ref } from 'vue'
+import { useAuthStore, useUserStore } from '@ownclouders/web-pkg'
+import { useGettext } from 'vue3-gettext'
+import { computeDiff, diffToText } from '../utils/diff'
+import type { LlmConfig } from './useLlm'
+
+const MAX_DIFF_CHARS = 8_000
+
+export interface ChangelogEntry {
+  summary: string
+}
+
+export type ContentFetcher = () => Promise<string>
+
+export interface UseChangelogResult {
+  generateEntry: (cacheKey: string, fetchOld: ContentFetcher, fetchNew: ContentFetcher) => Promise<void>
+  getEntry: (cacheKey: string) => ChangelogEntry | undefined
+  isGeneratingKey: (cacheKey: string) => boolean
+  getError: (cacheKey: string) => string | undefined
+  clearError: (cacheKey: string) => void
+}
+
+export function useChangelog(llmConfig: LlmConfig | null | Ref<LlmConfig | null>): UseChangelogResult {
+  function getLlmConfig(): LlmConfig | null {
+    return isRef(llmConfig) ? llmConfig.value : llmConfig
+  }
+  const { $gettext, current: gettextLanguage } = useGettext()
+  const authStore = useAuthStore()
+  const userStore = useUserStore()
+
+  const cache = ref(new Map<string, ChangelogEntry>())
+  const generatingKeys = ref(new Set<string>())
+  const errors = ref(new Map<string, string>())
+
+  function buildHeaders(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' }
+    const token = authStore.accessToken
+    if (token) {
+      h['Authorization'] = `Bearer ${token}`
+    }
+    return h
+  }
+
+  function getUserLanguage(): string {
+    return userStore.user?.preferredLanguage || gettextLanguage
+  }
+
+  function aiErrorMessage(status: number): string {
+    if (status === 401 || status === 403) {
+      return $gettext(
+        'Access to the AI service was denied. Your session may have expired — try reloading the page.'
+      )
+    }
+    if (status === 404) {
+      return $gettext(
+        'The AI endpoint could not be found. Check the endpoint URL in admin settings.'
+      )
+    }
+    if (status === 429) {
+      return $gettext('The AI service is currently busy. Please try again in a moment.')
+    }
+    if (status >= 500) {
+      return $gettext('The AI service is temporarily unavailable. Please try again later.')
+    }
+    return $gettext('The AI service returned an unexpected response. Please try again.')
+  }
+
+  async function callLlm(diffText: string): Promise<ChangelogEntry> {
+    const config = getLlmConfig()
+    if (!config) {
+      throw new Error($gettext('Admin needs to configure the AI endpoint.'))
+    }
+
+    const base = config.endpoint.replace(/\/$/, '')
+    const lang = getUserLanguage()
+    const prompt = [
+      'The following is a unified diff between two versions of a document.',
+      `Respond in the language with BCP 47 tag "${lang}".`,
+      'Write one or two casual sentences describing what you changed, as if telling a colleague.',
+      'Focus on the actual content — what was added, removed, or updated — not on the fact that versions differ.',
+      'Example: "Added the budget forecast for Q3 and removed Bob from the attendees list."',
+      'Return only the sentences, no preamble.',
+      '\n\nDiff:\n' + diffText
+    ].join(' ')
+
+    const res = await fetch(`${base}/chat/completions`, {
+      method: 'POST',
+      headers: buildHeaders(),
+      signal: AbortSignal.timeout(30_000),
+      body: JSON.stringify({
+        model: config.model,
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 256
+      })
+    })
+
+    if (!res.ok) {
+      throw new Error(aiErrorMessage(res.status))
+    }
+
+    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> }
+    const text = data.choices?.[0]?.message?.content ?? ''
+
+    return { summary: text.trim() || $gettext('No changes detected.') }
+  }
+
+  async function generateEntry(
+    cacheKey: string,
+    fetchOld: ContentFetcher,
+    fetchNew: ContentFetcher
+  ): Promise<void> {
+    if (cache.value.has(cacheKey) || generatingKeys.value.has(cacheKey)) {
+      return
+    }
+
+    generatingKeys.value.add(cacheKey)
+    errors.value.delete(cacheKey)
+
+    try {
+      const [oldContent, newContent] = await Promise.all([fetchOld(), fetchNew()])
+      const hunks = computeDiff(oldContent, newContent)
+      const diffText = diffToText(hunks).slice(0, MAX_DIFF_CHARS)
+
+      if (!diffText.trim()) {
+        if (oldContent !== newContent) {
+          errors.value.set(
+            cacheKey,
+            $gettext('This file is too large to compare. Only files with up to 2,000 lines are supported.')
+          )
+          return
+        }
+        cache.value.set(cacheKey, {
+          summary: $gettext('No text changes detected between these versions.')
+        })
+        return
+      }
+
+      const entry = await callLlm(diffText)
+      cache.value.set(cacheKey, entry)
+    } catch (err: unknown) {
+      let msg: string
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        msg = $gettext('The AI service did not respond in time. Please try again later.')
+      } else if (err instanceof TypeError) {
+        msg = $gettext('Could not reach the AI service. Check your network connection and try again.')
+      } else {
+        msg = err instanceof Error ? err.message : $gettext('Something went wrong. Please try again.')
+      }
+      errors.value.set(cacheKey, msg)
+    } finally {
+      generatingKeys.value.delete(cacheKey)
+    }
+  }
+
+  function getEntry(cacheKey: string): ChangelogEntry | undefined {
+    return cache.value.get(cacheKey)
+  }
+
+  function isGeneratingKey(cacheKey: string): boolean {
+    return generatingKeys.value.has(cacheKey)
+  }
+
+  function getError(cacheKey: string): string | undefined {
+    return errors.value.get(cacheKey)
+  }
+
+  function clearError(cacheKey: string): void {
+    errors.value.delete(cacheKey)
+  }
+
+  return { generateEntry, getEntry, isGeneratingKey, getError, clearError }
+}

--- a/packages/web-app-version-changelog/src/composables/useLlm.ts
+++ b/packages/web-app-version-changelog/src/composables/useLlm.ts
@@ -1,0 +1,26 @@
+import { ref, type Ref } from 'vue'
+
+export interface LlmConfig {
+  endpoint: string
+  model: string
+}
+
+export type LlmStatus = 'unconfigured' | 'ready'
+
+export interface UseLlmResult {
+  status: Ref<LlmStatus>
+  config: Ref<LlmConfig | null>
+  ensureReady: () => Promise<void>
+}
+
+export function useLlm(initialConfig: LlmConfig | null): UseLlmResult {
+  const status = ref<LlmStatus>('unconfigured')
+  const config = ref<LlmConfig | null>(initialConfig)
+
+  function ensureReady(): Promise<void> {
+    status.value = config.value ? 'ready' : 'unconfigured'
+    return Promise.resolve()
+  }
+
+  return { status, config, ensureReady }
+}

--- a/packages/web-app-version-changelog/src/composables/useVersionHistory.ts
+++ b/packages/web-app-version-changelog/src/composables/useVersionHistory.ts
@@ -1,0 +1,53 @@
+import { ref, type Ref } from 'vue'
+import { useClientService } from '@ownclouders/web-pkg'
+import { useGettext } from 'vue3-gettext'
+import type { Resource } from '@ownclouders/web-client'
+
+export type VersionHistoryResource = Resource
+
+export interface UseVersionHistoryResult {
+  versions: Ref<VersionHistoryResource[]>
+  isLoading: Ref<boolean>
+  error: Ref<string | null>
+  fetchVersions: (fileId: string) => Promise<void>
+}
+
+export function useVersionHistory(): UseVersionHistoryResult {
+  const { $gettext } = useGettext()
+  const clientService = useClientService()
+
+  const versions = ref<VersionHistoryResource[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchVersions(fileId: string): Promise<void> {
+    isLoading.value = true
+    error.value = null
+    versions.value = []
+
+    try {
+      const raw = await clientService.webdav.listFileVersions(fileId)
+      versions.value = [...raw].sort((a, b) => {
+        const ma = a.mdate ? (new Date(a.mdate).getTime() || 0) : 0
+        const mb = b.mdate ? (new Date(b.mdate).getTime() || 0) : 0
+        return mb - ma
+      })
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        if (err.message.includes('404') || err.message.includes('Not Found')) {
+          error.value = $gettext('No version history found for this file.')
+        } else if (err.message.includes('401') || err.message.includes('403')) {
+          error.value = $gettext('Access denied. Your session may have expired.')
+        } else {
+          error.value = $gettext('Failed to load version history.')
+        }
+      } else {
+        error.value = $gettext('Failed to load version history.')
+      }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  return { versions, isLoading, error, fetchVersions }
+}

--- a/packages/web-app-version-changelog/src/index.ts
+++ b/packages/web-app-version-changelog/src/index.ts
@@ -5,6 +5,7 @@ import { useGettext } from 'vue3-gettext'
 import type { Resource, SpaceResource } from '@ownclouders/web-client'
 import ChangelogPanel from './components/ChangelogPanel.vue'
 import type { LlmConfig } from './composables/useLlm'
+import translations from '../l10n/translations.json'
 
 const APP_ID = 'version-changelog'
 
@@ -54,6 +55,7 @@ export default defineWebApplication({
         name: $pgettext('Version Changelog extension name', 'Version Changelog'),
         id: APP_ID
       },
+      translations,
       extensions
     }
   }

--- a/packages/web-app-version-changelog/src/index.ts
+++ b/packages/web-app-version-changelog/src/index.ts
@@ -1,0 +1,47 @@
+import { defineWebApplication } from '@ownclouders/web-pkg'
+import type { SidebarPanelExtension } from '@ownclouders/web-pkg'
+import { computed } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import type { Resource, SpaceResource } from '@ownclouders/web-client'
+import ChangelogPanel from './components/ChangelogPanel.vue'
+import type { LlmConfig } from './composables/useLlm'
+
+const APP_ID = 'version-changelog'
+
+export default defineWebApplication({
+  setup({ applicationConfig }) {
+    const { $pgettext } = useGettext()
+
+    const rawLlm = applicationConfig?.llm as Record<string, string> | undefined
+    const llmConfig: LlmConfig | null =
+      rawLlm?.endpoint && rawLlm?.model ? { endpoint: rawLlm.endpoint, model: rawLlm.model } : null
+
+    const extensions = computed(() => [
+      {
+        id: `${APP_ID}.panel`,
+        type: 'sidebarPanel',
+        extensionPointIds: ['global.files.sidebar'],
+        panel: {
+          name: APP_ID,
+          icon: 'history',
+          title: () => $pgettext('Sidebar panel tab title', 'Changelog'),
+          isVisible: ({ items }: { items?: Array<{ isFolder?: boolean }> }) =>
+            items?.length === 1 && !items[0]?.isFolder,
+          component: ChangelogPanel,
+          componentAttrs: ({ items }: { items?: Resource[] }) => ({
+            resource: items?.[0] ?? null,
+            llmConfig
+          })
+        }
+      } as SidebarPanelExtension<SpaceResource, Resource, Resource>
+    ])
+
+    return {
+      appInfo: {
+        name: $pgettext('Version Changelog extension name', 'Version Changelog'),
+        id: APP_ID
+      },
+      extensions
+    }
+  }
+})

--- a/packages/web-app-version-changelog/src/index.ts
+++ b/packages/web-app-version-changelog/src/index.ts
@@ -13,8 +13,21 @@ export default defineWebApplication({
     const { $pgettext } = useGettext()
 
     const rawLlm = applicationConfig?.llm as Record<string, string> | undefined
-    const llmConfig: LlmConfig | null =
-      rawLlm?.endpoint && rawLlm?.model ? { endpoint: rawLlm.endpoint, model: rawLlm.model } : null
+    let llmConfig: LlmConfig | null = null
+    if (rawLlm?.endpoint && rawLlm?.model) {
+      try {
+        const resolved = new URL(rawLlm.endpoint, window.location.href)
+        if (resolved.origin === window.location.origin) {
+          llmConfig = { endpoint: rawLlm.endpoint, model: rawLlm.model }
+        } else {
+          console.error(
+            '[version-changelog] LLM endpoint must be same-origin. Changelog generation disabled.'
+          )
+        }
+      } catch {
+        console.error('[version-changelog] Invalid LLM endpoint URL. Changelog generation disabled.')
+      }
+    }
 
     const extensions = computed(() => [
       {

--- a/packages/web-app-version-changelog/src/utils/diff.ts
+++ b/packages/web-app-version-changelog/src/utils/diff.ts
@@ -1,0 +1,110 @@
+export type DiffLineType = 'unchanged' | 'removed' | 'added'
+
+export interface DiffLine {
+  type: DiffLineType
+  text: string
+}
+
+export interface DiffHunk {
+  lines: DiffLine[]
+}
+
+const MAX_DIFF_LINES = 2000
+
+function lcsLineDiff(a: string[], b: string[]): DiffLine[] {
+  const m = a.length
+  const n = b.length
+
+  if (m > MAX_DIFF_LINES || n > MAX_DIFF_LINES) {
+    return []
+  }
+
+  const w = n + 1
+  const dp = new Uint32Array((m + 1) * w)
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i * w + j] = dp[(i - 1) * w + (j - 1)] + 1
+      } else {
+        const up = dp[(i - 1) * w + j]
+        const left = dp[i * w + (j - 1)]
+        dp[i * w + j] = up > left ? up : left
+      }
+    }
+  }
+
+  const result: DiffLine[] = []
+  let i = m
+  let j = n
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      result.push({ type: 'unchanged', text: a[i - 1] })
+      i--
+      j--
+    } else if (j > 0 && (i === 0 || dp[i * w + (j - 1)] >= dp[(i - 1) * w + j])) {
+      result.push({ type: 'added', text: b[j - 1] })
+      j--
+    } else {
+      result.push({ type: 'removed', text: a[i - 1] })
+      i--
+    }
+  }
+  result.reverse()
+  return result
+}
+
+export function computeDiff(original: string, proposed: string, context = 3): DiffHunk[] {
+  const a = original.split('\n')
+  const b = proposed.split('\n')
+  const lines = lcsLineDiff(a, b)
+
+  const changedIndices = new Set<number>()
+  lines.forEach((l, i) => {
+    if (l.type !== 'unchanged') {
+      changedIndices.add(i)
+    }
+  })
+
+  if (changedIndices.size === 0) {
+    return []
+  }
+
+  const visible = new Set<number>()
+  changedIndices.forEach((idx) => {
+    for (let k = Math.max(0, idx - context); k <= Math.min(lines.length - 1, idx + context); k++) {
+      visible.add(k)
+    }
+  })
+
+  const sorted = [...visible].sort((a, b) => a - b)
+  const hunks: DiffHunk[] = []
+  let current: DiffLine[] = []
+
+  for (let k = 0; k < sorted.length; k++) {
+    if (k > 0 && sorted[k] !== sorted[k - 1] + 1) {
+      hunks.push({ lines: current })
+      current = []
+    }
+    current.push(lines[sorted[k]])
+  }
+  if (current.length > 0) {
+    hunks.push({ lines: current })
+  }
+
+  return hunks
+}
+
+export function diffToText(hunks: DiffHunk[]): string {
+  return hunks
+    .map((hunk) =>
+      hunk.lines
+        .map((line) => {
+          if (line.type === 'added') { return `+ ${line.text}` }
+          if (line.type === 'removed') { return `- ${line.text}` }
+          return `  ${line.text}`
+        })
+        .join('\n')
+    )
+    .join('\n...\n')
+}

--- a/packages/web-app-version-changelog/tests/e2e/versionChangelog.spec.ts
+++ b/packages/web-app-version-changelog/tests/e2e/versionChangelog.spec.ts
@@ -1,0 +1,173 @@
+import { test, type Page, type APIRequestContext, expect } from '@playwright/test'
+import { createContext, closeContext } from '../../../../support/helpers/actorHelper'
+import { LoginPage } from '../../../../support/pages/loginPage'
+import { FilesPage } from '../../../../support/pages/filesPage'
+import { VersionChangelogPage } from '../../../../support/pages/versionChangelogPage'
+
+const TEST_FILENAME = 'version-changelog-test.txt'
+
+const INITIAL_CONTENT = `Introduction
+
+This document describes the initial project scope.
+Core features include data import and basic filtering.
+Performance requirements are to be defined later.`
+
+const UPDATED_CONTENT = `Introduction
+
+This document describes the updated project scope with clearer milestones.
+Core features include data import, advanced filtering, and CSV export.
+Performance requirements: response time under 200ms for standard queries.
+
+Performance Benchmarks
+
+Initial benchmarks show 150ms average response time for small datasets.`
+
+const MOCK_LLM_RESPONSE = {
+  choices: [
+    {
+      message: {
+        content:
+          'Added a performance benchmarks section and updated the scope to include CSV export and a 200ms response time target.'
+      }
+    }
+  ]
+}
+
+let adminPage: Page
+
+/** Upload the test file twice via WebDAV to create one stored version in OcIS. */
+async function createFileVersions(request: APIRequestContext): Promise<void> {
+  const auth = Buffer.from('admin:admin').toString('base64')
+  for (const content of [INITIAL_CONTENT, UPDATED_CONTENT]) {
+    await request.put(`/remote.php/dav/files/admin/${TEST_FILENAME}`, {
+      data: content,
+      headers: { 'Content-Type': 'text/plain', Authorization: `Basic ${auth}` }
+    })
+  }
+}
+
+test.describe('Version Changelog panel', () => {
+  test.beforeEach(async ({ browser, request }) => {
+    const { page } = await createContext(browser)
+
+    // Inject an LLM config into the OcIS web config before the app initialises so the
+    // Generate button is enabled during tests.  The mock LLM endpoint is intercepted
+    // separately per-test via page.route('**/chat/completions', ...).
+    // If OcIS serves the web config at a path other than /config.json in your deployment,
+    // update the route pattern below accordingly.
+    await page.route('**/config.json', async (route) => {
+      try {
+        const response = await route.fetch()
+        const body = (await response.json()) as Record<string, unknown>
+        const options = (body.options as Record<string, unknown>) ?? {}
+        await route.fulfill({
+          status: response.status(),
+          headers: response.headers(),
+          body: JSON.stringify({
+            ...body,
+            options: {
+              ...options,
+              llm: { endpoint: 'https://llm.mock.invalid/v1', model: 'test-model' }
+            }
+          })
+        })
+      } catch {
+        await route.continue()
+      }
+    })
+
+    const loginPage = new LoginPage(page)
+    await page.goto('/')
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().endsWith('logon') &&
+          resp.status() === 200 &&
+          resp.request().method() === 'POST'
+      ),
+      loginPage.login('admin', 'admin')
+    ])
+
+    adminPage = page
+
+    await createFileVersions(request)
+  })
+
+  test.afterEach(async () => {
+    const filesPage = new FilesPage(adminPage)
+    await filesPage.deleteAllFromPersonal()
+    const context = adminPage.context()
+    const loginPage = new LoginPage(adminPage)
+    await loginPage.logout()
+    await closeContext(context)
+  })
+
+  test('changelog panel is visible in the sidebar for a text file', async () => {
+    const changelog = new VersionChangelogPage(adminPage)
+    await changelog.openFor(TEST_FILENAME)
+    await expect(changelog.panel).toBeVisible()
+  })
+
+  test('panel renders one version row for a file with one stored version', async () => {
+    const changelog = new VersionChangelogPage(adminPage)
+    await changelog.openFor(TEST_FILENAME)
+    await expect(changelog.versionRows()).toHaveCount(1)
+  })
+
+  test('Generate renders the LLM summary as plain text', async () => {
+    await adminPage.route('**/chat/completions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(MOCK_LLM_RESPONSE)
+      })
+    })
+
+    const changelog = new VersionChangelogPage(adminPage)
+    await changelog.openFor(TEST_FILENAME)
+    await changelog.generateButton().click()
+
+    await expect(changelog.panel.locator('.changelog-entry-plain')).toBeVisible()
+    await expect(changelog.panel).toContainText('performance benchmarks section')
+  })
+
+  test('Generate shows an error message when the LLM returns 500', async () => {
+    await adminPage.route('**/chat/completions', async (route) => {
+      await route.fulfill({ status: 500 })
+    })
+
+    const changelog = new VersionChangelogPage(adminPage)
+    await changelog.openFor(TEST_FILENAME)
+    await changelog.generateButton().click()
+
+    await expect(changelog.entryError()).toBeVisible()
+    await expect(changelog.entryError()).toContainText('temporarily unavailable')
+    await expect(changelog.retryButton()).toBeVisible()
+  })
+
+  test('Retry button clears the error and re-runs generation', async () => {
+    let callCount = 0
+    await adminPage.route('**/chat/completions', async (route) => {
+      callCount += 1
+      if (callCount === 1) {
+        await route.fulfill({ status: 500 })
+      } else {
+        await route.fulfill({
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(MOCK_LLM_RESPONSE)
+        })
+      }
+    })
+
+    const changelog = new VersionChangelogPage(adminPage)
+    await changelog.openFor(TEST_FILENAME)
+    await changelog.generateButton().click()
+
+    await expect(changelog.entryError()).toBeVisible()
+    await changelog.retryButton().click()
+
+    await expect(changelog.entryError()).not.toBeVisible()
+    await expect(changelog.panel.locator('.changelog-entry-plain')).toBeVisible()
+  })
+})

--- a/packages/web-app-version-changelog/tests/unit/App.spec.ts
+++ b/packages/web-app-version-changelog/tests/unit/App.spec.ts
@@ -1,0 +1,5 @@
+describe('AI Version Changelog extension', () => {
+  it('has a test', () => {
+    expect(true).toBeTruthy()
+  })
+})

--- a/packages/web-app-version-changelog/tests/unit/ChangelogPanel.spec.ts
+++ b/packages/web-app-version-changelog/tests/unit/ChangelogPanel.spec.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+
+vi.mock('vue3-gettext', () => ({
+  useGettext: () => ({
+    $gettext: (s: string, params?: Record<string, unknown>) => {
+      if (params) {
+        return s.replace(/%\{(\w+)\}/g, (_, k) => String(params[k] ?? ''))
+      }
+      return s
+    },
+    $pgettext: (_ctx: string, s: string) => s
+  })
+}))
+
+vi.mock('../../src/composables/useVersionHistory')
+vi.mock('../../src/composables/useChangelog')
+
+vi.mock('@ownclouders/web-pkg', () => ({
+  useClientService: vi.fn(),
+  useConfigStore: vi.fn(),
+  useSpacesStore: vi.fn()
+}))
+
+import ChangelogPanel from '../../src/components/ChangelogPanel.vue'
+import { useVersionHistory } from '../../src/composables/useVersionHistory'
+import { useChangelog } from '../../src/composables/useChangelog'
+import { useClientService, useConfigStore, useSpacesStore } from '@ownclouders/web-pkg'
+import type { ChangelogEntry } from '../../src/composables/useChangelog'
+
+const fetchVersionsMock = vi.fn()
+const generateEntryMock = vi.fn()
+const clearErrorMock = vi.fn()
+
+function setupVersionHistoryMock({
+  versions = [] as any[],
+  isLoading = false,
+  error = null as string | null
+} = {}) {
+  vi.mocked(useVersionHistory).mockReturnValue({
+    versions: ref(versions),
+    isLoading: ref(isLoading),
+    error: ref(error),
+    fetchVersions: fetchVersionsMock
+  })
+}
+
+function setupChangelogMock({
+  entries = {} as Record<string, any>,
+  generatingKeys = new Set<string>(),
+  errors = {} as Record<string, string>
+} = {}) {
+  vi.mocked(useChangelog).mockReturnValue({
+    generateEntry: generateEntryMock,
+    getEntry: (key: string) => entries[key],
+    isGeneratingKey: (key: string) => generatingKeys.has(key),
+    getError: (key: string) => errors[key],
+    clearError: clearErrorMock
+  })
+}
+
+function setupServiceMocks() {
+  vi.mocked(useClientService).mockReturnValue({
+    httpAuthenticated: { get: vi.fn() },
+    webdav: { getFileContents: vi.fn(), listFileVersions: vi.fn() }
+  } as any)
+  vi.mocked(useConfigStore).mockReturnValue({ serverUrl: 'https://server.example.com' } as any)
+  vi.mocked(useSpacesStore).mockReturnValue({ getSpace: vi.fn().mockReturnValue(null) } as any)
+}
+
+function makeVersion(index: number) {
+  return {
+    id: `v${index}`,
+    name: `Version ${index}`,
+    mdate: new Date(2024, 0, index).toUTCString(),
+    etag: `etag-${index}`,
+    path: `/meta/file-abc/v/${index}`
+  }
+}
+
+function createWrapper(props: Record<string, unknown> = {}) {
+  return mount(ChangelogPanel, {
+    props: {
+      resource: null,
+      llmConfig: null,
+      ...props
+    },
+    global: {
+      stubs: {
+        OcButton: {
+          template: '<button v-bind="$attrs"><slot /></button>',
+          inheritAttrs: false
+        }
+      }
+    }
+  })
+}
+
+describe('ChangelogPanel', () => {
+  beforeEach(() => {
+    fetchVersionsMock.mockReset()
+    generateEntryMock.mockReset()
+    clearErrorMock.mockReset()
+    setupVersionHistoryMock()
+    setupChangelogMock()
+    setupServiceMocks()
+  })
+
+  describe('unconfigured banner', () => {
+    it('shows config notice when llmConfig is null', async () => {
+      const wrapper = createWrapper({ llmConfig: null })
+      await flushPromises()
+      expect(wrapper.find('.changelog-notice').exists()).toBe(true)
+    })
+
+    it('hides config notice when llmConfig is provided', async () => {
+      setupVersionHistoryMock({ versions: [makeVersion(1)] })
+      const wrapper = createWrapper({ llmConfig: { endpoint: 'http://llm.local/v1', model: 'llama3' } })
+      await flushPromises()
+      expect(wrapper.find('.changelog-notice').exists()).toBe(false)
+    })
+  })
+
+  describe('loading state', () => {
+    it('shows loading text while versions are loading', async () => {
+      setupVersionHistoryMock({ isLoading: true })
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.changelog-placeholder').text()).toContain('Loading version history')
+    })
+  })
+
+  describe('error state', () => {
+    it('shows error message when history fetch fails', async () => {
+      setupVersionHistoryMock({ error: 'Failed to load version history.' })
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.changelog-error').text()).toBe('Failed to load version history.')
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows placeholder when no versions exist', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.changelog-placeholder').text()).toContain('No version history')
+    })
+  })
+
+  describe('version list', () => {
+    it('renders a row for each version', async () => {
+      setupVersionHistoryMock({ versions: [makeVersion(1), makeVersion(2)] })
+      const wrapper = createWrapper({ resource: { fileId: 'file-abc', id: 'file-abc', mimeType: 'text/plain' } })
+      await flushPromises()
+      expect(wrapper.findAll('[data-testid="version-row"]')).toHaveLength(2)
+    })
+
+    it('shows Generate button disabled when llmConfig is null', async () => {
+      setupVersionHistoryMock({ versions: [makeVersion(1)] })
+      const wrapper = createWrapper({ resource: { fileId: 'file-abc', id: 'file-abc', mimeType: 'text/plain' }, llmConfig: null })
+      await flushPromises()
+      const btn = wrapper.find('button')
+      expect(btn.attributes('disabled')).toBeDefined()
+    })
+
+    it('shows Generate button enabled when llmConfig is provided and no entry cached', async () => {
+      setupVersionHistoryMock({ versions: [makeVersion(1)] })
+      const wrapper = createWrapper({ resource: { fileId: 'file-abc', id: 'file-abc', mimeType: 'text/plain' }, llmConfig: { endpoint: 'http://llm.local/v1', model: 'm' } })
+      await flushPromises()
+      const btn = wrapper.find('button')
+      expect(btn.attributes('disabled')).toBeUndefined()
+    })
+
+    it('calls generateEntry when Generate is clicked', async () => {
+      setupVersionHistoryMock({ versions: [makeVersion(1)] })
+      generateEntryMock.mockResolvedValue(undefined)
+      const wrapper = createWrapper({ resource: { fileId: 'file-abc', id: 'file-abc', mimeType: 'text/plain' }, llmConfig: { endpoint: 'http://llm.local/v1', model: 'm' } })
+      await flushPromises()
+      await wrapper.find('button').trigger('click')
+      expect(generateEntryMock).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('entry rendering', () => {
+    it('renders a changelog entry as a plain summary paragraph', async () => {
+      const v = makeVersion(1)
+      const entry: ChangelogEntry = { summary: 'Q3 figures were added and the draft watermark was removed.' }
+      setupVersionHistoryMock({ versions: [v] })
+      setupChangelogMock({ entries: { [`file-abc:${v.etag}`]: entry } })
+      const wrapper = createWrapper({
+        resource: { fileId: 'file-abc', storageId: 's1', id: 'f1', mimeType: 'text/plain' },
+        llmConfig: { endpoint: 'http://x.local/v1', model: 'm' }
+      })
+      await flushPromises()
+      expect(wrapper.find('.changelog-entry-plain').text()).toBe(
+        'Q3 figures were added and the draft watermark was removed.'
+      )
+    })
+
+    it('shows "Generating…" text when a key is generating', async () => {
+      const v = makeVersion(1)
+      setupVersionHistoryMock({ versions: [v] })
+      setupChangelogMock({ generatingKeys: new Set([`file-abc:${v.etag}`]) })
+      const wrapper = createWrapper({
+        resource: { fileId: 'file-abc', storageId: 's1', id: 'f1', mimeType: 'text/plain' },
+        llmConfig: { endpoint: 'http://x.local/v1', model: 'm' }
+      })
+      await flushPromises()
+      expect(wrapper.find('.changelog-generating').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Generating')
+    })
+
+    it('shows inline error with Retry button', async () => {
+      const v = makeVersion(1)
+      setupVersionHistoryMock({ versions: [v] })
+      setupChangelogMock({ errors: { [`file-abc:${v.etag}`]: 'AI service unavailable.' } })
+      const wrapper = createWrapper({
+        resource: { fileId: 'file-abc', storageId: 's1', id: 'f1', mimeType: 'text/plain' },
+        llmConfig: { endpoint: 'http://x.local/v1', model: 'm' }
+      })
+      await flushPromises()
+      expect(wrapper.find('.changelog-entry-error').text()).toContain('AI service unavailable.')
+      expect(wrapper.text()).toContain('Retry')
+    })
+
+    it('calls clearError and generateEntry again when Retry is clicked', async () => {
+      const v = makeVersion(1)
+      setupVersionHistoryMock({ versions: [v] })
+      setupChangelogMock({ errors: { [`file-abc:${v.etag}`]: 'Error.' } })
+      generateEntryMock.mockResolvedValue(undefined)
+      const wrapper = createWrapper({
+        resource: { fileId: 'file-abc', storageId: 's1', id: 'f1', mimeType: 'text/plain' },
+        llmConfig: { endpoint: 'http://x.local/v1', model: 'm' }
+      })
+      await flushPromises()
+      const retryBtn = wrapper.findAll('button').find((b) => b.text() === 'Retry')
+      await retryBtn!.trigger('click')
+      expect(clearErrorMock).toHaveBeenCalledOnce()
+      expect(generateEntryMock).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('binary file detection', () => {
+    it('shows binary notice for image files', async () => {
+      const wrapper = createWrapper({
+        resource: { fileId: 'f1', mimeType: 'image/png', id: 'f1' }
+      })
+      await flushPromises()
+      expect(wrapper.find('.changelog-placeholder').text()).toContain('Binary files')
+    })
+
+    it('does not show binary notice for text files', async () => {
+      const wrapper = createWrapper({
+        resource: { fileId: 'f1', mimeType: 'text/plain', id: 'f1' }
+      })
+      await flushPromises()
+      expect(wrapper.find('.changelog-placeholder').exists()).toBe(true)
+      expect(wrapper.find('.changelog-placeholder').text()).not.toContain('Binary')
+    })
+  })
+
+  describe('lifecycle', () => {
+    it('calls fetchVersions on mount when resource has a fileId', async () => {
+      createWrapper({ resource: { fileId: 'file-abc', id: 'file-abc', name: 'doc.txt', mimeType: 'text/plain' } })
+      await flushPromises()
+      expect(fetchVersionsMock).toHaveBeenCalledWith('file-abc')
+    })
+  })
+})

--- a/packages/web-app-version-changelog/tests/unit/diff.spec.ts
+++ b/packages/web-app-version-changelog/tests/unit/diff.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { computeDiff, diffToText } from '../../src/utils/diff'
+
+describe('computeDiff', () => {
+  it('returns empty array for identical content', () => {
+    expect(computeDiff('a\nb\nc', 'a\nb\nc')).toEqual([])
+  })
+
+  it('detects an added line', () => {
+    const hunks = computeDiff('a\nb', 'a\nb\nc')
+    const lines = hunks.flatMap((h) => h.lines)
+    expect(lines.some((l) => l.type === 'added' && l.text === 'c')).toBe(true)
+  })
+
+  it('detects a removed line', () => {
+    const hunks = computeDiff('a\nb\nc', 'a\nc')
+    const lines = hunks.flatMap((h) => h.lines)
+    expect(lines.some((l) => l.type === 'removed' && l.text === 'b')).toBe(true)
+  })
+
+  it('returns empty array when either side exceeds MAX_DIFF_LINES (2000)', () => {
+    const longText = Array.from({ length: 2001 }, (_, i) => `line ${i}`).join('\n')
+    expect(computeDiff(longText, 'short')).toEqual([])
+    expect(computeDiff('short', longText)).toEqual([])
+  })
+
+  it('groups nearby changes into a single hunk', () => {
+    const old = Array.from({ length: 20 }, (_, i) => `line ${i}`).join('\n')
+    const updated = old.replace('line 10', 'line TEN')
+    const hunks = computeDiff(old, updated)
+    expect(hunks.length).toBe(1)
+  })
+
+  it('splits distant changes into separate hunks', () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line ${i}`)
+    const updated = [...lines]
+    updated[0] = 'changed-first'
+    updated[49] = 'changed-last'
+    const hunks = computeDiff(lines.join('\n'), updated.join('\n'))
+    expect(hunks.length).toBeGreaterThan(1)
+  })
+
+  it('handles empty old content (new lines are added)', () => {
+    const hunks = computeDiff('', 'a\nb')
+    const lines = hunks.flatMap((h) => h.lines)
+    expect(lines.some((l) => l.type === 'added' && l.text === 'a')).toBe(true)
+    expect(lines.some((l) => l.type === 'added' && l.text === 'b')).toBe(true)
+  })
+
+  it('handles empty new content (old lines are removed)', () => {
+    const hunks = computeDiff('a\nb', '')
+    const lines = hunks.flatMap((h) => h.lines)
+    expect(lines.some((l) => l.type === 'removed' && l.text === 'a')).toBe(true)
+    expect(lines.some((l) => l.type === 'removed' && l.text === 'b')).toBe(true)
+  })
+})
+
+describe('diffToText', () => {
+  it('prefixes added lines with "+"', () => {
+    const hunks = computeDiff('a', 'a\nb')
+    expect(diffToText(hunks)).toContain('+ b')
+  })
+
+  it('prefixes removed lines with "-"', () => {
+    const hunks = computeDiff('a\nb', 'a')
+    expect(diffToText(hunks)).toContain('- b')
+  })
+
+  it('prefixes unchanged context lines with two spaces', () => {
+    const hunks = computeDiff('a\nb\nc', 'a\nB\nc')
+    const text = diffToText(hunks)
+    expect(text).toContain('  a')
+    expect(text).toContain('  c')
+  })
+
+  it('separates hunks with "..."', () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line ${i}`)
+    const updated = [...lines]
+    updated[0] = 'changed-first'
+    updated[49] = 'changed-last'
+    const hunks = computeDiff(lines.join('\n'), updated.join('\n'))
+    expect(diffToText(hunks)).toContain('...')
+  })
+
+  it('returns empty string for empty hunks array', () => {
+    expect(diffToText([])).toBe('')
+  })
+})

--- a/packages/web-app-version-changelog/tests/unit/useChangelog.spec.ts
+++ b/packages/web-app-version-changelog/tests/unit/useChangelog.spec.ts
@@ -139,4 +139,52 @@ describe('useChangelog', () => {
     clearError('key10')
     expect(getError('key10')).toBeUndefined()
   })
+
+  it('sends Authorization header with the access token', async () => {
+    const llmResponse = { choices: [{ message: { content: 'summary' } }] }
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse(llmResponse) as any)
+    const { generateEntry } = useChangelog(BASE_CONFIG)
+    await generateEntry('key-auth', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer test-token' })
+  })
+
+  it('omits Authorization header when no access token is available', async () => {
+    vi.mocked(useAuthStore).mockReturnValue({ accessToken: '' } as any)
+    const llmResponse = { choices: [{ message: { content: 'summary' } }] }
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse(llmResponse) as any)
+    const { generateEntry } = useChangelog(BASE_CONFIG)
+    await generateEntry('key-noauth', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    expect((init as RequestInit & { headers: Record<string, string> }).headers).not.toHaveProperty(
+      'Authorization'
+    )
+  })
+
+  it('sets error message on AbortSignal timeout (DOMException TimeoutError)', async () => {
+    const timeout = Object.assign(new DOMException('Timeout', 'TimeoutError'))
+    vi.mocked(fetch).mockRejectedValueOnce(timeout)
+    const { generateEntry, getError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key-timeout', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key-timeout')).toContain('did not respond in time')
+  })
+
+  it('sets error message on network failure (TypeError)', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    const { generateEntry, getError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key-network', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key-network')).toContain('network')
+  })
+
+  it('uses array index as cache key fallback when version has no etag', () => {
+    // cacheKey is built in ChangelogPanel, but the composable must accept any string key
+    const { generateEntry, getEntry } = useChangelog(BASE_CONFIG)
+    const llmResponse = { choices: [{ message: { content: 'ok' } }] }
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse(llmResponse) as any)
+    // Two different index-based keys should be independent
+    const key0 = 'file123:0'
+    const key1 = 'file123:1'
+    void generateEntry(key0, () => Promise.resolve('a'), () => Promise.resolve('b'))
+    expect(getEntry(key1)).toBeUndefined()
+  })
 })

--- a/packages/web-app-version-changelog/tests/unit/useChangelog.spec.ts
+++ b/packages/web-app-version-changelog/tests/unit/useChangelog.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('vue3-gettext', () => ({
+  useGettext: () => ({ $gettext: (s: string) => s, current: 'en' })
+}))
+
+vi.mock('@ownclouders/web-pkg', () => ({
+  useAuthStore: vi.fn(),
+  useUserStore: vi.fn()
+}))
+
+vi.mock('../../src/utils/diff', () => ({
+  computeDiff: vi.fn(),
+  diffToText: vi.fn()
+}))
+
+import { useChangelog } from '../../src/composables/useChangelog'
+import { useAuthStore, useUserStore } from '@ownclouders/web-pkg'
+import { computeDiff, diffToText } from '../../src/utils/diff'
+import type { LlmConfig } from '../../src/composables/useLlm'
+
+const BASE_CONFIG: LlmConfig = { endpoint: 'http://localhost:3000/ai/v1', model: 'test-model' }
+
+function makeFetchResponse(body: unknown, ok = true, status = 200) {
+  return Promise.resolve({
+    ok,
+    status,
+    json: () => Promise.resolve(body)
+  })
+}
+
+function setupMocks() {
+  vi.mocked(useAuthStore).mockReturnValue({ accessToken: 'test-token' } as any)
+  vi.mocked(useUserStore).mockReturnValue({ user: { preferredLanguage: 'en' } } as any)
+  vi.mocked(computeDiff).mockReturnValue([{ lines: [{ type: 'added', text: 'new line' }] }])
+  vi.mocked(diffToText).mockReturnValue('+ new line')
+}
+
+describe('useChangelog', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    setupMocks()
+  })
+
+  it('returns undefined for unknown cache key', () => {
+    const { getEntry } = useChangelog(BASE_CONFIG)
+    expect(getEntry('unknown-key')).toBeUndefined()
+  })
+
+  it('stores LLM response text as summary', async () => {
+    const llmResponse = {
+      choices: [{ message: { content: 'Q3 figures were added and the draft watermark was removed.' } }]
+    }
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse(llmResponse) as any)
+    const { generateEntry, getEntry } = useChangelog(BASE_CONFIG)
+    await generateEntry('key1', () => Promise.resolve('old content'), () => Promise.resolve('new content'))
+    expect(getEntry('key1')?.summary).toBe('Q3 figures were added and the draft watermark was removed.')
+  })
+
+  it('trims whitespace from LLM response', async () => {
+    const llmResponse = {
+      choices: [{ message: { content: '  The document was updated with new figures.  ' } }]
+    }
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse(llmResponse) as any)
+    const { generateEntry, getEntry } = useChangelog(BASE_CONFIG)
+    await generateEntry('key2', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getEntry('key2')?.summary).toBe('The document was updated with new figures.')
+  })
+
+  it('caches result and skips LLM on second call', async () => {
+    const llmResponse = {
+      choices: [{ message: { content: '{"added":["x"],"removed":[],"modified":[]}' } }]
+    }
+    vi.mocked(fetch).mockReturnValue(makeFetchResponse(llmResponse) as any)
+    const { generateEntry, getEntry } = useChangelog(BASE_CONFIG)
+    await generateEntry('key3', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    await generateEntry('key3', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(getEntry('key3')).toBeDefined()
+  })
+
+  it('sets error on HTTP 401', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse({}, false, 401) as any)
+    const { generateEntry, getError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key4', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key4')).toContain('denied')
+  })
+
+  it('sets error on HTTP 404', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse({}, false, 404) as any)
+    const { generateEntry, getError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key5', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key5')).toContain('endpoint could not be found')
+  })
+
+  it('sets error on HTTP 429', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse({}, false, 429) as any)
+    const { generateEntry, getError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key6', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key6')).toContain('busy')
+  })
+
+  it('sets error on HTTP 500', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse({}, false, 500) as any)
+    const { generateEntry, getError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key7', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key7')).toContain('unavailable')
+  })
+
+  it('sets summary when diff is empty and contents are identical', async () => {
+    vi.mocked(computeDiff).mockReturnValueOnce([])
+    vi.mocked(diffToText).mockReturnValueOnce('')
+    const { generateEntry, getEntry } = useChangelog(BASE_CONFIG)
+    await generateEntry('key8', () => Promise.resolve('same'), () => Promise.resolve('same'))
+    expect(getEntry('key8')?.summary).toContain('No text changes')
+  })
+
+  it('sets error when files differ but diff is empty (too large to compare)', async () => {
+    vi.mocked(computeDiff).mockReturnValueOnce([])
+    vi.mocked(diffToText).mockReturnValueOnce('')
+    const { generateEntry, getError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key-large', () => Promise.resolve('old content'), () => Promise.resolve('new content'))
+    expect(getError('key-large')).toContain('too large')
+  })
+
+  it('does nothing when llmConfig is null', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse({}) as any)
+    const { generateEntry, getError } = useChangelog(null)
+    await generateEntry('key9', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key9')).toBeDefined()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('clearError removes the error', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(makeFetchResponse({}, false, 500) as any)
+    const { generateEntry, getError, clearError } = useChangelog(BASE_CONFIG)
+    await generateEntry('key10', () => Promise.resolve('old'), () => Promise.resolve('new'))
+    expect(getError('key10')).toBeDefined()
+    clearError('key10')
+    expect(getError('key10')).toBeUndefined()
+  })
+})

--- a/packages/web-app-version-changelog/tests/unit/useVersionHistory.spec.ts
+++ b/packages/web-app-version-changelog/tests/unit/useVersionHistory.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('vue3-gettext', () => ({
+  useGettext: () => ({ $gettext: (s: string) => s })
+}))
+
+vi.mock('@ownclouders/web-pkg', () => ({
+  useClientService: vi.fn()
+}))
+
+import { useVersionHistory } from '../../src/composables/useVersionHistory'
+import { useClientService } from '@ownclouders/web-pkg'
+
+function makeVersion(dateStr: string, etag: string) {
+  return { mdate: dateStr, etag, id: etag, name: `v-${etag}`, type: 'file' }
+}
+
+let listFileVersionsMock: ReturnType<typeof vi.fn>
+
+function setupClientServiceMock() {
+  listFileVersionsMock = vi.fn()
+  vi.mocked(useClientService).mockReturnValue({
+    webdav: { listFileVersions: listFileVersionsMock }
+  } as any)
+}
+
+describe('useVersionHistory', () => {
+  beforeEach(() => {
+    setupClientServiceMock()
+  })
+
+  it('returns empty list and not loading initially', () => {
+    listFileVersionsMock.mockResolvedValue([])
+    const { versions, isLoading, error } = useVersionHistory()
+    expect(versions.value).toEqual([])
+    expect(isLoading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('sets isLoading during fetch', async () => {
+    let resolve!: (v: any) => void
+    listFileVersionsMock.mockReturnValue(new Promise((r) => { resolve = r }))
+    const { isLoading, fetchVersions } = useVersionHistory()
+    const promise = fetchVersions('file-123')
+    expect(isLoading.value).toBe(true)
+    resolve([])
+    await promise
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('returns versions sorted newest-first', async () => {
+    const older = makeVersion('Mon, 01 Jan 2024 10:00:00 GMT', 'etag-a')
+    const newer = makeVersion('Tue, 02 Jan 2024 10:00:00 GMT', 'etag-b')
+    listFileVersionsMock.mockResolvedValue([older, newer])
+    const { versions, fetchVersions } = useVersionHistory()
+    await fetchVersions('file-123')
+    expect(versions.value[0].etag).toBe('etag-b')
+    expect(versions.value[1].etag).toBe('etag-a')
+  })
+
+  it('sets translated error on failure', async () => {
+    listFileVersionsMock.mockRejectedValue(new Error('Network error'))
+    const { error, fetchVersions } = useVersionHistory()
+    await fetchVersions('file-123')
+    expect(error.value).toBe('Failed to load version history.')
+  })
+
+  it('sets access denied error on 401', async () => {
+    listFileVersionsMock.mockRejectedValue(new Error('401 Unauthorized'))
+    const { error, fetchVersions } = useVersionHistory()
+    await fetchVersions('file-123')
+    expect(error.value).toBe('Access denied. Your session may have expired.')
+  })
+
+  it('sets not found error on 404', async () => {
+    listFileVersionsMock.mockRejectedValue(new Error('404 Not Found'))
+    const { error, fetchVersions } = useVersionHistory()
+    await fetchVersions('file-123')
+    expect(error.value).toBe('No version history found for this file.')
+  })
+})

--- a/packages/web-app-version-changelog/tsconfig.json
+++ b/packages/web-app-version-changelog/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@ownclouders/tsconfig",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}
+

--- a/packages/web-app-version-changelog/vite.config.ts
+++ b/packages/web-app-version-changelog/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@ownclouders/extension-sdk'
+
+export default defineConfig({
+  name: 'web-app-version-changelog',
+  server: {
+    port: 9731
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'index.js'
+      }
+    }
+  },
+  test: {
+    exclude: ['**/e2e/**']
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,9 +474,6 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,14 +444,65 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@5.9.3))
 
+  packages/web-app-version-changelog:
+    dependencies:
+      '@ownclouders/web-client':
+        specifier: ^12.3.2
+        version: 12.3.2
+      '@ownclouders/web-pkg':
+        specifier: ^12.3.2
+        version: 12.3.2(@vue/compiler-sfc@3.5.35)(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))
+    devDependencies:
+      '@ownclouders/extension-sdk':
+        specifier: 12.3.2
+        version: 12.3.2(vite@7.2.2(@types/node@22.19.19)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
+      '@ownclouders/tsconfig':
+        specifier: 0.0.6
+        version: 0.0.6
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))
+      eslint:
+        specifier: 9.39.4
+        version: 9.39.4
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 7.2.2
+        version: 7.2.2(@types/node@22.19.19)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.7
+        version: 4.1.7(@types/node@22.19.19)(happy-dom@20.9.0)(vite@7.2.2(@types/node@22.19.19)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0))
+      vue:
+        specifier: ^3.4.21
+        version: 3.5.35(typescript@5.9.3)
+      vue-router:
+        specifier: ^5.0.7
+        version: 5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(vite@7.2.2(@types/node@22.19.19)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
+      vue-tsc:
+        specifier: 3.3.2
+        version: 3.3.2(typescript@5.9.3)
+      vue3-gettext:
+        specifier: ^2.4.0
+        version: 2.4.0(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@5.9.3))
+
 packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
-
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -505,10 +556,6 @@ packages:
   '@babel/helper-string-parser@8.0.0-rc.6':
     resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
     engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
@@ -2220,9 +2267,6 @@ packages:
     peerDependencies:
       vue: 3.5.35
 
-  '@vue/shared@3.5.34':
-    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
-
   '@vue/shared@3.5.35':
     resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
 
@@ -2265,11 +2309,6 @@ packages:
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -3780,10 +3819,6 @@ packages:
     resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
     engines: {node: '>=18'}
 
-  p-queue@9.2.0:
-    resolution: {integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==}
-    engines: {node: '>=20'}
-
   p-queue@9.3.0:
     resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
     engines: {node: '>=20'}
@@ -4003,10 +4038,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -4214,11 +4245,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.0:
@@ -4910,12 +4936,6 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -5006,8 +5026,6 @@ snapshots:
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-string-parser@8.0.0-rc.6': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -6050,7 +6068,7 @@ snapshots:
       '@uppy/utils': 7.1.5
       '@uppy/xhr-upload': 5.1.1(@uppy/core@5.2.0)
       '@vavt/cm-extension': 1.11.2
-      '@vue/shared': 3.5.34
+      '@vue/shared': 3.5.35
       '@vueuse/core': 14.3.0(vue@3.5.35(typescript@5.9.3))
       axios: 1.16.1
       deepmerge: 4.3.1
@@ -6068,14 +6086,14 @@ snapshots:
       md-editor-v3: 6.5.0(vue@3.5.35(typescript@5.9.3))
       mermaid: 11.15.0
       oidc-client-ts: 3.5.0
-      p-queue: 9.2.0
+      p-queue: 9.3.0
       password-sheriff: 2.0.0
       pdf-lib: 1.17.1
       pinia: 3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))
       portal-vue: 3.0.0(vue@3.5.35(typescript@5.9.3))
       prettier: 3.8.3
       prismjs: 1.30.0
-      qs: 6.15.1
+      qs: 6.15.2
       screenfull: 6.0.2
       uuid: 13.0.2
       vue-concurrency: 5.0.3(vue@3.5.35(typescript@5.9.3))
@@ -6747,7 +6765,7 @@ snapshots:
   '@uppy/drop-target@4.1.0(@uppy/core@5.2.0)':
     dependencies:
       '@uppy/core': 5.2.0
-      '@uppy/utils': 7.1.5
+      '@uppy/utils': 7.2.0
 
   '@uppy/google-drive@5.1.0(@uppy/core@5.2.0)':
     dependencies:
@@ -6787,7 +6805,7 @@ snapshots:
     dependencies:
       '@uppy/companion-client': 5.1.1(@uppy/core@5.2.0)
       '@uppy/core': 5.2.0
-      '@uppy/utils': 7.1.5
+      '@uppy/utils': 7.2.0
       tus-js-client: 4.3.1
 
   '@uppy/utils@7.1.5':
@@ -6812,7 +6830,7 @@ snapshots:
     dependencies:
       '@uppy/companion-client': 5.1.1(@uppy/core@5.2.0)
       '@uppy/core': 5.2.0
-      '@uppy/utils': 7.1.5
+      '@uppy/utils': 7.2.0
 
   '@upsetjs/venn.js@2.0.0':
     optionalDependencies:
@@ -7061,8 +7079,6 @@ snapshots:
       '@vue/shared': 3.5.35
       vue: 3.5.35(typescript@5.9.3)
 
-  '@vue/shared@3.5.34': {}
-
   '@vue/shared@3.5.35': {}
 
   '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3))':
@@ -7091,10 +7107,6 @@ snapshots:
 
   abbrev@2.0.0: {}
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -7102,8 +7114,6 @@ snapshots:
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.16.0
-
-  acorn@8.15.0: {}
 
   acorn@8.16.0: {}
 
@@ -7628,7 +7638,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.1
-      semver: 7.7.3
+      semver: 7.8.0
 
   electron-to-chromium@1.5.364: {}
 
@@ -8046,8 +8056,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
@@ -8799,11 +8809,6 @@ snapshots:
       eventemitter3: 5.0.4
       p-timeout: 6.1.4
 
-  p-queue@9.2.0:
-    dependencies:
-      eventemitter3: 5.0.4
-      p-timeout: 7.0.1
-
   p-queue@9.3.0:
     dependencies:
       eventemitter3: 5.0.4
@@ -8831,7 +8836,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -8986,10 +8991,6 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
-
-  qs@6.15.1:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.15.2:
     dependencies:
@@ -9183,8 +9184,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.3: {}
-
   semver@7.8.0: {}
 
   shallow-equal@3.1.0: {}
@@ -9369,7 +9368,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.19.19
-      acorn: 8.15.0
+      acorn: 8.16.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -9387,7 +9386,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 24.12.4
-      acorn: 8.15.0
+      acorn: 8.16.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1

--- a/support/actions/ocis.apps.yaml
+++ b/support/actions/ocis.apps.yaml
@@ -8,7 +8,7 @@ web-app-chat-with-file:
       endpoint: 'https://localhost:9200/ai-llm-proxy/v1'
       model: 'llama3.2'
 
-version-changelog:
+web-app-version-changelog:
   config:
     llm:
       endpoint: 'https://localhost:9200/ai-llm-proxy/v1'

--- a/support/actions/ocis.apps.yaml
+++ b/support/actions/ocis.apps.yaml
@@ -8,7 +8,7 @@ web-app-chat-with-file:
       endpoint: 'https://localhost:9200/ai-llm-proxy/v1'
       model: 'llama3.2'
 
-web-app-version-changelog:
+version-changelog:
   config:
     llm:
       endpoint: 'https://localhost:9200/ai-llm-proxy/v1'

--- a/support/actions/ocis.apps.yaml
+++ b/support/actions/ocis.apps.yaml
@@ -7,3 +7,9 @@ web-app-chat-with-file:
     llm:
       endpoint: 'https://localhost:9200/ai-llm-proxy/v1'
       model: 'llama3.2'
+
+web-app-version-changelog:
+  config:
+    llm:
+      endpoint: 'https://localhost:9200/ai-llm-proxy/v1'
+      model: 'llama3.2'

--- a/support/pages/versionChangelogPage.ts
+++ b/support/pages/versionChangelogPage.ts
@@ -1,0 +1,45 @@
+import { Locator, Page } from '@playwright/test'
+import { FilesPage } from './filesPage'
+
+export class VersionChangelogPage {
+  readonly page: Page
+  readonly sidebar: Locator
+  readonly panel: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.sidebar = this.page.getByTestId('app-sidebar')
+    this.panel = this.page.getByTestId('version-changelog-panel')
+  }
+
+  versionRows(): Locator {
+    return this.panel.getByTestId('version-row')
+  }
+
+  generateButton(rowIndex = 0): Locator {
+    return this.versionRows().nth(rowIndex).getByRole('button', { name: 'Generate' })
+  }
+
+  retryButton(rowIndex = 0): Locator {
+    return this.versionRows().nth(rowIndex).getByRole('button', { name: 'Retry' })
+  }
+
+  entryError(rowIndex = 0): Locator {
+    return this.versionRows().nth(rowIndex).locator('.changelog-entry-error')
+  }
+
+  changelogTab(): Locator {
+    return this.sidebar.getByRole('button', { name: 'Changelog' })
+  }
+
+  /** Opens the file's context menu and clicks "Details" to open the sidebar, then switches to the Changelog tab. */
+  async openFor(filename: string): Promise<void> {
+    const files = new FilesPage(this.page)
+    await files.openFileContextMenu(filename)
+    await this.page.getByTestId('action-label').filter({ hasText: 'Details' }).click()
+    await this.sidebar.waitFor({ state: 'visible' })
+    await this.changelogTab().waitFor({ state: 'visible' })
+    await this.changelogTab().click()
+    await this.panel.waitFor({ state: 'visible' })
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new web-app-version-changelog extension that registers a Changelog sidebar panel
in the file details sidebar. When a single file is selected, the panel lists its
version history and lets users generate a plain-English description of what changed in
each version — powered by a BYO LLM endpoint.

- Each version row shows a Generate button that fetches the two version blobs
on-demand, diffs them, and sends the diff to a configured OpenAI-compatible endpoint
- Generated summaries are cached for the session; a Retry button appears on failure
- The panel is hidden for folders and shows an informational message for binary files
- Responses are requested in the user's preferred language (BCP 47 tag passed in the
prompt)
- The user's auth token is forwarded to the LLM endpoint

## Screenshots

<img width="460" height="195" alt="image" src="https://github.com/user-attachments/assets/76f23f9f-70ff-4da7-8035-1b115cabc863" />

<img width="465" height="232" alt="image" src="https://github.com/user-attachments/assets/492a81de-8315-41e7-9510-d4d01cc10b0d" />


## Configuration

Add the following to the app's entry in apps.yaml:

```yml
- id: version-changelog
  path: ...
  config:
    llm:
      endpoint: https://your-llm-host/v1
      model: your-model-name
```

Without configuration the panel still appears, but all Generate buttons are disabled
with a notice to configure the AI endpoint in admin settings.

## Limitations

- Text files only; binary files show a placeholder message
- Files longer than 2,000 lines cannot be compared (an error is shown per version row)
- The diff sent to the LLM is capped at 8,000 characters

## Test plan

- [ ] Select a versioned text file — Changelog tab appears in the sidebar
- [ ] Click Generate on a version row — summary appears after a moment
- [ ] Click Generate again on the same row — no second request is made (cached)
- [ ] Simulate an LLM error — error message and Retry button appear
- [ ] Click Retry — clears the error and re-generates
- [ ] Select a binary file — binary placeholder is shown, no Generate buttons
- [ ] Remove llm config — Generate buttons are disabled with the admin notice
- [ ] Select a folder — Changelog tab does not appear
