### PR TITLE
fix: add missing apps to README and version-changelog Transifex config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Web Extensions are available on [Docker Hub](https://hub.docker.com/r/owncloud/w
 ### Included Extensions
 
 - [web-app-advanced-search](packages/web-app-advanced-search/) -- Advanced search capabilities
+- [web-app-ai-doc-summary](packages/web-app-ai-doc-summary/) -- AI-generated document summaries
 - [web-app-cast](packages/web-app-cast/) -- Cast files to external devices
+- [web-app-chat-with-file](packages/web-app-chat-with-file/) -- AI chat about file content
 - [web-app-draw-io](packages/web-app-draw-io/) -- Draw.io diagram integration
 - [web-app-external-sites](packages/web-app-external-sites/) -- Embed external websites
 - [web-app-importer](packages/web-app-importer/) -- File import functionality

--- a/packages/web-app-version-changelog/l10n/.tx/config
+++ b/packages/web-app-version-changelog/l10n/.tx/config
@@ -1,0 +1,10 @@
+[main]
+host = https://www.transifex.com
+
+[o:owncloud-org:p:owncloud-web:r:web-extensions-version-changelog]
+file_filter = locale/<lang>/app.po
+minimum_perc = 0
+resource_name = web-extensions-version-changelog
+source_file = template.pot
+source_lang = en
+type = PO


### PR DESCRIPTION
## Summary

- Add `web-app-ai-doc-summary` and `web-app-chat-with-file` to the README extensions list (both were missing)
- Sort the extensions list alphabetically
- Add missing `l10n/.tx/config` for `web-app-version-changelog` (matching the pattern of all other packages)

## Test plan

- [ ] Verify the README extensions list is complete and alphabetically sorted
- [ ] Verify `packages/web-app-version-changelog/l10n/.tx/config` matches the format of sibling packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)