### PR TITLE
feat(group-management): add group management app extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
           - web-app-chat-with-file
           - ai-llm-proxy
           - web-app-version-changelog
+          - web-app-group-management
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - ./packages/web-app-ai-doc-summary/dist:/web/apps/ai-doc-summary
       - ./packages/web-app-chat-with-file/dist:/web/apps/chat-with-file
       - ./packages/web-app-version-changelog/dist:/web/apps/version-changelog
+      - ./packages/web-app-group-management/dist:/web/apps/group-management
     depends_on:
       - traefik
 

--- a/packages/web-app-group-management/LICENSE
+++ b/packages/web-app-group-management/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 ownCloud GmbH
+   
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/web-app-group-management/README.md
+++ b/packages/web-app-group-management/README.md
@@ -1,0 +1,63 @@
+# Group Management
+
+[![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+
+An ownCloud Infinite Scale (oCIS) full-app extension for managing groups and their members from
+a single, focused screen. It registers an app-menu entry ("Group Management") and a route, and
+talks exclusively to the public LibreGraph API through the oCIS web client.
+
+The view is a two-pane layout: a searchable list of groups on the left, and a detail panel on the
+right showing the selected group's members with controls to add and remove them.
+
+## Features
+
+- List groups (server-side search by name)
+- Create a group
+- Rename a group
+- Delete a group (with confirmation)
+- View a group's members
+- Add users to a group via a searchable user picker (server-side user search)
+- Remove a user from a group (with confirmation)
+- Read-only groups (`groupTypes: ["ReadOnly"]`) are clearly marked and their mutate actions are disabled
+- Success and failure feedback through the standard oCIS message toasts
+- Bulk member adds report per-user success/failure (one network call per user, settled independently)
+
+## Scope: what oCIS supports
+
+This extension is deliberately scoped to what the oCIS / LibreGraph backend actually models for
+groups. Two capabilities that a "complete" MS-Graph-style group manager might expect are **not**
+available in oCIS and are therefore intentionally absent here:
+
+- **Nested groups.** A group's members are always users (`Group.members` is `User[]`). LibreGraph
+  has no group-in-group relationship and the web client's `addMember` only accepts a user
+  reference, so there is no group tree, no parent/child groups, and no circular-dependency
+  handling — none of it would have anything to call.
+- **Group description.** oCIS groups expose only `id`, `displayName` and `groupTypes`. The
+  MS-Graph `description` field is not persisted by the backend, so the create/edit form does not
+  offer it.
+
+If oCIS gains these capabilities, the extension can be extended to match.
+
+## How it works
+
+- Built with `defineWebApplication` from `@ownclouders/web-pkg`; registers an `appMenuItem`
+  extension and a route rendering `GroupsView.vue`.
+- All group/member operations go through `clientService.graphAuthenticated.groups` / `.users`.
+- Dialogs use the imperative oCIS modal service (`useModals().dispatchModal`): simple
+  confirmations for delete/remove, and custom-component modals (`GroupFormModal`,
+  `AddMembersModal`) for forms.
+- The group list is a lightweight projection; selecting a group fetches the full group
+  (with members) on demand.
+
+## Development
+
+```bash
+# from the monorepo root
+pnpm --filter ./packages/web-app-group-management build      # production build -> dist/group-management.js
+pnpm --filter ./packages/web-app-group-management test:unit  # unit tests (Vitest)
+pnpm --filter ./packages/web-app-group-management check:types
+```
+
+To run it in the local dev stack, build it and bring up the root `docker-compose.yml` (the app's
+`dist` is mounted at `/web/apps/group-management`), then open the "Group Management" entry from the
+application switcher.

--- a/packages/web-app-group-management/l10n/.tx/config
+++ b/packages/web-app-group-management/l10n/.tx/config
@@ -1,0 +1,10 @@
+[main]
+host = https://www.transifex.com
+
+[o:owncloud-org:p:owncloud-web:r:web-extensions-group-management]
+file_filter = locale/<lang>/app.po
+minimum_perc = 0
+resource_name = web-extensions-group-management
+source_file = template.pot
+source_lang = en
+type = PO

--- a/packages/web-app-group-management/l10n/translations.json
+++ b/packages/web-app-group-management/l10n/translations.json
@@ -1,0 +1,3 @@
+{
+  "translations": {}
+}

--- a/packages/web-app-group-management/package.json
+++ b/packages/web-app-group-management/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "group-management",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Group management full-app extension for ownCloud Web",
+  "license": "Apache-2.0",
+  "author": "ownCloud GmbH",
+  "type": "module",
+  "scripts": {
+    "build": "pnpm vite build",
+    "build:w": "pnpm vite build --watch --mode development",
+    "check:types": "vue-tsc --noEmit",
+    "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest run",
+    "test:e2e": "pnpm playwright test"
+  },
+  "dependencies": {
+    "@ownclouders/web-client": "^12.3.2",
+    "@ownclouders/web-pkg": "^12.3.2"
+  },
+  "devDependencies": {
+    "@ownclouders/extension-sdk": "^12.3.2",
+    "@ownclouders/web-test-helpers": "^12.3.2",
+    "vue": "^3.5.35",
+    "vue-router": "^5.1.0",
+    "vue3-gettext": "^2.4.0"
+  }
+}

--- a/packages/web-app-group-management/playwright.config.ts
+++ b/packages/web-app-group-management/playwright.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@playwright/test'
+import baseConfig from '../../playwright.config'
+
+export default defineConfig({
+  ...baseConfig,
+  testDir: './tests/e2e'
+})

--- a/packages/web-app-group-management/public/manifest.json
+++ b/packages/web-app-group-management/public/manifest.json
@@ -1,0 +1,3 @@
+{
+  "entrypoint": "group-management.js"
+}

--- a/packages/web-app-group-management/src/components/AddMembersModal.vue
+++ b/packages/web-app-group-management/src/components/AddMembersModal.vue
@@ -49,6 +49,9 @@ const userOptions = ref<User[]>([])
 const searching = ref(false)
 
 let searchTimeout: ReturnType<typeof setTimeout> | null = null
+// Monotonic counter so a slower, older search response cannot overwrite the
+// results of a newer one (the onMounted empty search races debounced typing).
+let searchRequestId = 0
 
 const existingMemberIds = () => new Set((props.group.members ?? []).map((m) => m.id))
 
@@ -58,17 +61,26 @@ const existingMemberIds = () => new Set((props.group.members ?? []).map((m) => m
 const serverSideFilter = (users: User[]) => users
 
 const runSearch = async (query: string) => {
+  const requestId = ++searchRequestId
   searching.value = true
   try {
     const members = existingMemberIds()
     const selected = new Set(unref(selectedUsers).map((u) => u.id))
     const users = await searchUsers(query)
+    if (requestId !== searchRequestId) {
+      return // a newer search has superseded this one -- discard stale results
+    }
     userOptions.value = users.filter((u) => !members.has(u.id) && !selected.has(u.id))
   } catch (error) {
+    if (requestId !== searchRequestId) {
+      return
+    }
     console.error(error)
     userOptions.value = []
   } finally {
-    searching.value = false
+    if (requestId === searchRequestId) {
+      searching.value = false
+    }
   }
 }
 
@@ -126,6 +138,14 @@ const onConfirm = async () => {
     })
   }
 
+  if (!succeeded.length) {
+    // Nothing was added: reject so the modal framework keeps the dialog open
+    // and the user can retry without reopening it.
+    throw new Error('No members were added')
+  }
+
+  // At least one member was added. The mutation already succeeded, so a failed
+  // re-fetch must not be reported as an error; hand back best-effort data.
   try {
     const updated = await getGroup(props.group.id)
     props.onSaved?.(updated)

--- a/packages/web-app-group-management/src/components/AddMembersModal.vue
+++ b/packages/web-app-group-management/src/components/AddMembersModal.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="group-management-add-members">
+    <oc-select
+      :model-value="selectedUsers"
+      :multiple="true"
+      :options="userOptions"
+      option-label="displayName"
+      :loading="searching"
+      :label="$gettext('Users')"
+      :fix-message-line="true"
+      :placeholder="$gettext('Search users...')"
+      :filter="serverSideFilter"
+      @update:model-value="onSelect"
+      @search:input="onSearch"
+    >
+      <template #option="{ displayName, mail }">
+        <span class="oc-text-truncate">{{ displayName }}</span>
+        <span v-if="mail" class="oc-text-muted oc-ml-s">{{ mail }}</span>
+      </template>
+      <template #no-options>{{ $gettext('No users found') }}</template>
+    </oc-select>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, unref, watch } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { Modal, useMessages } from '@ownclouders/web-pkg'
+import { Group, User } from '@ownclouders/web-client/graph/generated'
+import { useGroupManagement } from '../composables/useGroupManagement'
+
+const props = defineProps<{
+  modal: Modal
+  group: Group
+  onSaved?: (group: Group) => void
+}>()
+
+const emit = defineEmits<{
+  (e: 'confirm'): void
+  (e: 'update:confirmDisabled', value: boolean): void
+}>()
+
+const { $gettext, $ngettext } = useGettext()
+const { showMessage, showErrorMessage } = useMessages()
+const { searchUsers, addMembers, getGroup } = useGroupManagement()
+
+const selectedUsers = ref<User[]>([])
+const userOptions = ref<User[]>([])
+const searching = ref(false)
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+
+const existingMemberIds = () => new Set((props.group.members ?? []).map((m) => m.id))
+
+// The user list is already filtered server-side via $search; returning the
+// options unchanged disables oc-select's default client-side (Fuse) filter,
+// which would otherwise hide users matched only by mail or username.
+const serverSideFilter = (users: User[]) => users
+
+const runSearch = async (query: string) => {
+  searching.value = true
+  try {
+    const members = existingMemberIds()
+    const selected = new Set(unref(selectedUsers).map((u) => u.id))
+    const users = await searchUsers(query)
+    userOptions.value = users.filter((u) => !members.has(u.id) && !selected.has(u.id))
+  } catch (error) {
+    console.error(error)
+    userOptions.value = []
+  } finally {
+    searching.value = false
+  }
+}
+
+const onSearch = (query: string) => {
+  if (searchTimeout) {
+    clearTimeout(searchTimeout)
+  }
+  searchTimeout = setTimeout(() => runSearch(query), 250)
+}
+
+const onSelect = (users: User[]) => {
+  selectedUsers.value = users
+}
+
+watch(
+  selectedUsers,
+  () => {
+    emit('update:confirmDisabled', unref(selectedUsers).length === 0)
+  },
+  { immediate: true }
+)
+
+onMounted(() => runSearch(''))
+
+const onConfirm = async () => {
+  const users = unref(selectedUsers)
+  if (!users.length) {
+    return Promise.reject()
+  }
+
+  const { succeeded, failed } = await addMembers(
+    props.group,
+    users.map((u) => u.id)
+  )
+
+  if (succeeded.length) {
+    showMessage({
+      title: $ngettext(
+        '%{count} member was added',
+        '%{count} members were added',
+        succeeded.length,
+        { count: succeeded.length.toString() }
+      )
+    })
+  }
+  if (failed.length) {
+    showErrorMessage({
+      title: $ngettext(
+        'Failed to add %{count} member',
+        'Failed to add %{count} members',
+        failed.length,
+        { count: failed.length.toString() }
+      ),
+      errors: failed.map((f) => f.reason)
+    })
+  }
+
+  try {
+    const updated = await getGroup(props.group.id)
+    props.onSaved?.(updated)
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+defineExpose({ onConfirm })
+</script>
+
+<style scoped>
+.group-management-add-members {
+  min-height: 12rem;
+}
+</style>

--- a/packages/web-app-group-management/src/components/GroupFormModal.vue
+++ b/packages/web-app-group-management/src/components/GroupFormModal.vue
@@ -1,0 +1,95 @@
+<template>
+  <form autocomplete="off" @submit.prevent="onConfirm">
+    <oc-text-input
+      id="group-management-input-display-name"
+      v-model="displayName"
+      class="oc-mb-s"
+      :label="$gettext('Group name') + ' *'"
+      :error-message="displayNameError"
+      :fix-message-line="true"
+      @update:model-value="validate"
+    />
+    <input type="submit" class="oc-hidden" />
+  </form>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, unref, watch } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { Modal, useMessages } from '@ownclouders/web-pkg'
+import { Group } from '@ownclouders/web-client/graph/generated'
+import { useGroupManagement } from '../composables/useGroupManagement'
+
+const props = defineProps<{
+  modal: Modal
+  group?: Group
+  onSaved?: (group: Group) => void
+}>()
+
+const emit = defineEmits<{
+  (e: 'confirm'): void
+  (e: 'update:confirmDisabled', value: boolean): void
+}>()
+
+const { $gettext } = useGettext()
+const { showMessage, showErrorMessage } = useMessages()
+const { createGroup, editGroup, getGroup } = useGroupManagement()
+
+const isEdit = computed(() => !!props.group?.id)
+
+const displayName = ref(props.group?.displayName ?? '')
+const displayNameError = ref('')
+
+const validate = () => {
+  const name = unref(displayName).trim()
+  if (!name) {
+    displayNameError.value = $gettext('Group name cannot be empty')
+    return false
+  }
+  if (name.length > 255) {
+    displayNameError.value = $gettext('Group name cannot exceed 255 characters')
+    return false
+  }
+  displayNameError.value = ''
+  return true
+}
+
+watch(
+  displayName,
+  () => {
+    emit('update:confirmDisabled', !validate())
+  },
+  { immediate: true }
+)
+
+const onConfirm = async () => {
+  if (!validate()) {
+    return Promise.reject()
+  }
+  const name = unref(displayName).trim()
+  try {
+    if (unref(isEdit)) {
+      await editGroup(props.group.id, name)
+      const updated = await getGroup(props.group.id)
+      showMessage({ title: $gettext('Group "%{group}" was saved', { group: name }) })
+      props.onSaved?.(updated)
+    } else {
+      const created = await createGroup(name)
+      // Re-fetch the canonical group (with members) before handing it back.
+      const full = await getGroup(created.id)
+      showMessage({ title: $gettext('Group "%{group}" was created', { group: name }) })
+      props.onSaved?.(full)
+    }
+  } catch (error) {
+    console.error(error)
+    showErrorMessage({
+      title: unref(isEdit)
+        ? $gettext('Failed to save group')
+        : $gettext('Failed to create group'),
+      errors: [error]
+    })
+  }
+}
+
+defineExpose({ onConfirm })
+</script>

--- a/packages/web-app-group-management/src/components/GroupFormModal.vue
+++ b/packages/web-app-group-management/src/components/GroupFormModal.vue
@@ -67,27 +67,48 @@ const onConfirm = async () => {
     return Promise.reject()
   }
   const name = unref(displayName).trim()
+  const editing = unref(isEdit)
+  // Capture the group identity before any await: the parent can unmount the
+  // modal (clearing `props.group`) during the async mutation, so a later
+  // `props.group.id` access would throw.
+  const original = props.group
+  const groupId = original?.id
+
+  let mutated: Group
   try {
-    if (unref(isEdit)) {
-      await editGroup(props.group.id, name)
-      const updated = await getGroup(props.group.id)
-      showMessage({ title: $gettext('Group "%{group}" was saved', { group: name }) })
-      props.onSaved?.(updated)
+    if (editing) {
+      await editGroup(groupId as string, name)
+      mutated = { ...(original as Group), id: groupId as string, displayName: name }
     } else {
-      const created = await createGroup(name)
-      // Re-fetch the canonical group (with members) before handing it back.
-      const full = await getGroup(created.id)
-      showMessage({ title: $gettext('Group "%{group}" was created', { group: name }) })
-      props.onSaved?.(full)
+      mutated = await createGroup(name)
     }
   } catch (error) {
     console.error(error)
     showErrorMessage({
-      title: unref(isEdit)
-        ? $gettext('Failed to save group')
-        : $gettext('Failed to create group'),
+      title: editing ? $gettext('Failed to save group') : $gettext('Failed to create group'),
       errors: [error]
     })
+    return
+  }
+
+  // The mutation succeeded on the server: confirm to the user and notify the
+  // parent now, independently of the canonical re-fetch below. Otherwise a
+  // transient re-fetch failure would show a false error and skip onSaved even
+  // though the group was actually saved.
+  showMessage({
+    title: editing
+      ? $gettext('Group "%{group}" was saved', { group: name })
+      : $gettext('Group "%{group}" was created', { group: name })
+  })
+
+  try {
+    const full = await getGroup(mutated.id)
+    props.onSaved?.(full)
+  } catch (error) {
+    // Re-fetch failed but the save itself succeeded; hand back the best-known
+    // group so the list still updates (it refreshes fully on the next load).
+    console.error(error)
+    props.onSaved?.(mutated)
   }
 }
 

--- a/packages/web-app-group-management/src/composables/useGroupManagement.ts
+++ b/packages/web-app-group-management/src/composables/useGroupManagement.ts
@@ -6,6 +6,13 @@ export interface MemberMutationResult {
   failed: { id: string; reason: Error }[]
 }
 
+// Escape a user-supplied term for use inside an OData `$search` phrase (which is
+// wrapped in double quotes). Without escaping, a typed `"` produces a malformed
+// expression and the Graph API returns 400 -- which would otherwise surface to
+// the user as an empty list / "no results" for a perfectly valid search.
+const quoteSearchTerm = (term: string): string =>
+  `"${term.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+
 /**
  * Thin, typed wrapper around the LibreGraph groups/users client.
  *
@@ -27,7 +34,7 @@ export function useGroupManagement() {
       .groups.listGroups({
         orderBy: ['displayName'],
         expand: ['members'],
-        ...(search ? { search: `"${search}"` } : {})
+        ...(search ? { search: quoteSearchTerm(search) } : {})
       })
       .then((groups) => groups ?? [])
 
@@ -51,7 +58,17 @@ export function useGroupManagement() {
    * Users already in the group are skipped.
    */
   const addMembers = async (group: Group, userIds: string[]): Promise<MemberMutationResult> => {
-    const existing = new Set((group.members ?? []).map((m) => m.id))
+    // Build the dedup set from live server state rather than the snapshot taken
+    // when the modal opened, so a user added concurrently by another admin is
+    // not added again (which would surface as a spurious per-user failure).
+    // Fall back to the snapshot if the refresh itself fails.
+    let existing: Set<string>
+    try {
+      const fresh = await getGroup(group.id)
+      existing = new Set((fresh.members ?? []).map((m) => m.id))
+    } catch {
+      existing = new Set((group.members ?? []).map((m) => m.id))
+    }
     const toAdd = userIds.filter((id) => !existing.has(id))
     const results = await Promise.allSettled(
       toAdd.map((userId) => graph().groups.addMember(group.id, userId))
@@ -77,7 +94,7 @@ export function useGroupManagement() {
     graph()
       .users.listUsers({
         orderBy: ['displayName'],
-        ...(search ? { search: `"${search}"` } : {})
+        ...(search ? { search: quoteSearchTerm(search) } : {})
       })
       .then((users) => users ?? [])
 

--- a/packages/web-app-group-management/src/composables/useGroupManagement.ts
+++ b/packages/web-app-group-management/src/composables/useGroupManagement.ts
@@ -1,0 +1,96 @@
+import { useClientService } from '@ownclouders/web-pkg'
+import { Group, User } from '@ownclouders/web-client/graph/generated'
+
+export interface MemberMutationResult {
+  succeeded: string[]
+  failed: { id: string; reason: Error }[]
+}
+
+/**
+ * Thin, typed wrapper around the LibreGraph groups/users client.
+ *
+ * Note on scope: oCIS / LibreGraph models group membership strictly as
+ * User -> memberOf -> Group (a group's `members` are always users). There is no
+ * group-in-group relationship in the graph client, so this extension manages
+ * user membership only and deliberately offers no "nested group" affordances.
+ */
+export function useGroupManagement() {
+  const clientService = useClientService()
+  const graph = () => clientService.graphAuthenticated
+
+  const isReadOnly = (group: Group): boolean => !!group.groupTypes?.includes('ReadOnly')
+
+  const memberCount = (group: Group): number => group.members?.length ?? 0
+
+  const listGroups = (search = ''): Promise<Group[]> =>
+    graph()
+      .groups.listGroups({
+        orderBy: ['displayName'],
+        expand: ['members'],
+        ...(search ? { search: `"${search}"` } : {})
+      })
+      .then((groups) => groups ?? [])
+
+  const getGroup = (id: string): Promise<Group> =>
+    graph().groups.getGroup(id, { expand: ['members'] })
+
+  // oCIS / LibreGraph groups expose only id, displayName and groupTypes. The
+  // MS-Graph "description" field is not persisted by the backend, so it is
+  // intentionally not part of the create/edit surface.
+  const createGroup = (displayName: string): Promise<Group> =>
+    graph().groups.createGroup({ displayName })
+
+  const editGroup = (id: string, displayName: string): Promise<void> =>
+    graph().groups.editGroup(id, { displayName })
+
+  const deleteGroup = (id: string): Promise<void> => graph().groups.deleteGroup(id)
+
+  /**
+   * Add several users to a group, reporting per-user success/failure so the
+   * caller can surface a combined toast (mirrors the admin-settings pattern).
+   * Users already in the group are skipped.
+   */
+  const addMembers = async (group: Group, userIds: string[]): Promise<MemberMutationResult> => {
+    const existing = new Set((group.members ?? []).map((m) => m.id))
+    const toAdd = userIds.filter((id) => !existing.has(id))
+    const results = await Promise.allSettled(
+      toAdd.map((userId) => graph().groups.addMember(group.id, userId))
+    )
+    return toAdd.reduce<MemberMutationResult>(
+      (acc, userId, index) => {
+        const result = results[index]
+        if (result.status === 'fulfilled') {
+          acc.succeeded.push(userId)
+        } else {
+          acc.failed.push({ id: userId, reason: result.reason as Error })
+        }
+        return acc
+      },
+      { succeeded: [], failed: [] }
+    )
+  }
+
+  const removeMember = (groupId: string, userId: string): Promise<void> =>
+    graph().groups.deleteMember(groupId, userId)
+
+  const searchUsers = (search = ''): Promise<User[]> =>
+    graph()
+      .users.listUsers({
+        orderBy: ['displayName'],
+        ...(search ? { search: `"${search}"` } : {})
+      })
+      .then((users) => users ?? [])
+
+  return {
+    isReadOnly,
+    memberCount,
+    listGroups,
+    getGroup,
+    createGroup,
+    editGroup,
+    deleteGroup,
+    addMembers,
+    removeMember,
+    searchUsers
+  }
+}

--- a/packages/web-app-group-management/src/env.d.ts
+++ b/packages/web-app-group-management/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly DEV: boolean
+  readonly PROD: boolean
+  readonly MODE: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/packages/web-app-group-management/src/index.ts
+++ b/packages/web-app-group-management/src/index.ts
@@ -1,0 +1,56 @@
+import { defineWebApplication, AppMenuItemExtension } from '@ownclouders/web-pkg'
+import { RouteRecordRaw } from 'vue-router'
+import { computed } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import GroupsView from './views/GroupsView.vue'
+import translations from '../l10n/translations.json'
+
+const appId = 'group-management'
+
+export default defineWebApplication({
+  setup() {
+    const { $gettext } = useGettext()
+
+    const appInfo = {
+      id: appId,
+      name: $gettext('Group Management'),
+      icon: 'group-2',
+      color: '#0D856F'
+    }
+
+    const routes: RouteRecordRaw[] = [
+      {
+        path: '/',
+        redirect: { name: `${appId}-overview` }
+      },
+      {
+        path: '/overview',
+        name: `${appId}-overview`,
+        component: GroupsView,
+        meta: {
+          authContext: 'user',
+          title: $gettext('Groups')
+        }
+      }
+    ]
+
+    const menuItems = computed<AppMenuItemExtension[]>(() => [
+      {
+        id: `app.${appId}.menuItem`,
+        type: 'appMenuItem',
+        label: () => appInfo.name,
+        color: appInfo.color,
+        icon: appInfo.icon,
+        priority: 30,
+        path: `/${appId}`
+      }
+    ])
+
+    return {
+      appInfo,
+      routes,
+      extensions: menuItems,
+      translations
+    }
+  }
+})

--- a/packages/web-app-group-management/src/views/GroupsView.vue
+++ b/packages/web-app-group-management/src/views/GroupsView.vue
@@ -1,0 +1,426 @@
+<template>
+  <div
+    class="group-management"
+    role="main"
+    :aria-label="$gettext('Group Management')"
+    data-testid="group-management-view"
+  >
+    <div class="group-management-sidebar">
+      <div class="group-management-sidebar-header">
+        <oc-text-input
+          v-model="searchTerm"
+          class="group-management-search"
+          :label="$gettext('Search groups')"
+          @update:model-value="onSearch"
+        />
+        <oc-button
+          variation="primary"
+          appearance="filled"
+          data-testid="group-management-create"
+          :aria-label="$gettext('Create group')"
+          @click="openCreateGroup"
+        >
+          <oc-icon name="add" />
+          <span>{{ $gettext('Create group') }}</span>
+        </oc-button>
+      </div>
+
+      <div v-if="loading" class="group-management-placeholder">
+        <oc-spinner :aria-label="$gettext('Loading groups...')" />
+      </div>
+      <ul v-else-if="groups.length" class="group-management-list" :aria-label="$gettext('Groups')">
+        <li
+          v-for="group in groups"
+          :key="group.id"
+          :class="['group-management-list-item', { 'is-selected': group.id === selectedGroupId }]"
+        >
+          <button
+            type="button"
+            class="group-management-list-select"
+            data-testid="group-management-group-row"
+            @click="selectGroup(group.id)"
+          >
+            <oc-icon name="group-2" class="oc-mr-s" />
+            <span class="oc-text-truncate">{{ group.displayName }}</span>
+            <span class="group-management-member-count">{{ memberCount(group) }}</span>
+          </button>
+          <span v-if="isReadOnly(group)" class="group-management-readonly-badge">
+            {{ $gettext('Read-only') }}
+          </span>
+        </li>
+      </ul>
+      <div v-else class="group-management-placeholder">
+        <p>{{ $gettext('No groups found') }}</p>
+      </div>
+    </div>
+
+    <div class="group-management-detail">
+      <template v-if="selectedGroup">
+        <div class="group-management-detail-header">
+          <h2 class="oc-text-truncate">{{ selectedGroup.displayName }}</h2>
+          <div class="group-management-detail-actions">
+            <oc-button
+              :disabled="isReadOnly(selectedGroup)"
+              :aria-label="$gettext('Edit group')"
+              @click="openEditGroup(selectedGroup)"
+            >
+              <oc-icon name="pencil" />
+              <span>{{ $gettext('Edit') }}</span>
+            </oc-button>
+            <oc-button
+              :disabled="isReadOnly(selectedGroup)"
+              :aria-label="$gettext('Delete group')"
+              @click="openDeleteGroup(selectedGroup)"
+            >
+              <oc-icon name="delete-bin" />
+              <span>{{ $gettext('Delete') }}</span>
+            </oc-button>
+          </div>
+        </div>
+
+        <div class="group-management-members">
+          <div class="group-management-members-header">
+            <h3>{{ $gettext('Members') }} ({{ memberCount(selectedGroup) }})</h3>
+            <oc-button
+              variation="primary"
+              appearance="filled"
+              :disabled="isReadOnly(selectedGroup)"
+              :aria-label="$gettext('Add members')"
+              @click="openAddMembers(selectedGroup)"
+            >
+              <oc-icon name="user-add" />
+              <span>{{ $gettext('Add members') }}</span>
+            </oc-button>
+          </div>
+
+          <ul v-if="memberCount(selectedGroup)" class="group-management-member-list">
+            <li
+              v-for="member in selectedGroup.members"
+              :key="member.id"
+              class="group-management-member"
+            >
+              <oc-icon name="user" class="oc-mr-s" />
+              <span class="oc-text-truncate group-management-member-name">
+                {{ member.displayName }}
+              </span>
+              <span v-if="member.mail" class="oc-text-muted oc-text-truncate">{{ member.mail }}</span>
+              <oc-button
+                appearance="raw"
+                class="group-management-member-remove"
+                :disabled="isReadOnly(selectedGroup)"
+                :aria-label="$gettext('Remove member')"
+                @click="openRemoveMember(selectedGroup, member)"
+              >
+                <oc-icon name="close" />
+              </oc-button>
+            </li>
+          </ul>
+          <p v-else class="is-muted">{{ $gettext('This group has no members yet.') }}</p>
+        </div>
+      </template>
+      <div v-else class="group-management-empty">
+        <oc-icon name="group-2" size="xlarge" />
+        <p>{{ $gettext('Select a group to view its details and members.') }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, unref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { useMessages, useModals } from '@ownclouders/web-pkg'
+import { Group, User } from '@ownclouders/web-client/graph/generated'
+import { useGroupManagement } from '../composables/useGroupManagement'
+import GroupFormModal from '../components/GroupFormModal.vue'
+import AddMembersModal from '../components/AddMembersModal.vue'
+
+const { $gettext } = useGettext()
+const { showMessage, showErrorMessage } = useMessages()
+const { dispatchModal } = useModals()
+const { listGroups, deleteGroup, removeMember, getGroup, isReadOnly, memberCount } =
+  useGroupManagement()
+
+const groups = ref<Group[]>([])
+const loading = ref(true)
+const selectedGroupId = ref<string | null>(null)
+const searchTerm = ref('')
+
+const selectedGroup = computed(
+  () => unref(groups).find((g) => g.id === unref(selectedGroupId)) ?? null
+)
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+
+const loadGroups = async (search = '') => {
+  loading.value = true
+  try {
+    groups.value = await listGroups(search)
+    if (unref(selectedGroupId) && !unref(selectedGroup)) {
+      selectedGroupId.value = null
+    }
+  } catch (error) {
+    console.error(error)
+    showErrorMessage({ title: $gettext('Failed to load groups'), errors: [error] })
+    groups.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+const onSearch = () => {
+  if (searchTimeout) {
+    clearTimeout(searchTimeout)
+  }
+  searchTimeout = setTimeout(() => loadGroups(unref(searchTerm).trim()), 300)
+}
+
+const selectGroup = async (id: string) => {
+  selectedGroupId.value = id
+  // The list endpoint returns a lightweight projection; fetch the full group
+  // (description + members) for the detail panel.
+  try {
+    upsertGroup(await getGroup(id))
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+const upsertGroup = (group: Group) => {
+  const index = unref(groups).findIndex((g) => g.id === group.id)
+  if (index === -1) {
+    groups.value = [...unref(groups), group].sort((a, b) =>
+      (a.displayName ?? '').localeCompare(b.displayName ?? '')
+    )
+  } else {
+    const next = [...unref(groups)]
+    next[index] = group
+    groups.value = next
+  }
+  selectedGroupId.value = group.id
+}
+
+const openCreateGroup = () => {
+  dispatchModal({
+    title: $gettext('Create group'),
+    confirmText: $gettext('Create'),
+    customComponent: GroupFormModal,
+    customComponentAttrs: () => ({ onSaved: upsertGroup })
+  })
+}
+
+const openEditGroup = (group: Group) => {
+  dispatchModal({
+    title: $gettext('Edit group'),
+    confirmText: $gettext('Save'),
+    customComponent: GroupFormModal,
+    customComponentAttrs: () => ({ group, onSaved: upsertGroup })
+  })
+}
+
+const openAddMembers = (group: Group) => {
+  dispatchModal({
+    title: $gettext('Add members to "%{group}"', { group: group.displayName }),
+    confirmText: $gettext('Add'),
+    customComponent: AddMembersModal,
+    customComponentAttrs: () => ({ group, onSaved: upsertGroup })
+  })
+}
+
+const deleteGroupConfirmed = async (group: Group) => {
+  try {
+    await deleteGroup(group.id)
+    showMessage({ title: $gettext('Group "%{group}" was deleted', { group: group.displayName }) })
+    groups.value = unref(groups).filter((g) => g.id !== group.id)
+    if (unref(selectedGroupId) === group.id) {
+      selectedGroupId.value = null
+    }
+  } catch (error) {
+    console.error(error)
+    showErrorMessage({
+      title: $gettext('Failed to delete group "%{group}"', { group: group.displayName }),
+      errors: [error]
+    })
+  }
+}
+
+const openDeleteGroup = (group: Group) => {
+  dispatchModal({
+    variation: 'danger',
+    title: $gettext('Delete group "%{group}"?', { group: group.displayName }),
+    confirmText: $gettext('Delete'),
+    message: $gettext(
+      'Are you sure you want to delete this group? Members will lose any access granted through it. This cannot be undone.'
+    ),
+    onConfirm: () => deleteGroupConfirmed(group)
+  })
+}
+
+const removeMemberConfirmed = async (group: Group, member: User) => {
+  try {
+    await removeMember(group.id, member.id)
+    showMessage({
+      title: $gettext('"%{member}" was removed from "%{group}"', {
+        member: member.displayName,
+        group: group.displayName
+      })
+    })
+    const updated = await getGroup(group.id)
+    upsertGroup(updated)
+  } catch (error) {
+    console.error(error)
+    showErrorMessage({
+      title: $gettext('Failed to remove "%{member}"', { member: member.displayName }),
+      errors: [error]
+    })
+  }
+}
+
+const openRemoveMember = (group: Group, member: User) => {
+  dispatchModal({
+    variation: 'danger',
+    title: $gettext('Remove "%{member}"?', { member: member.displayName }),
+    confirmText: $gettext('Remove'),
+    message: $gettext('Remove "%{member}" from "%{group}"?', {
+      member: member.displayName,
+      group: group.displayName
+    }),
+    onConfirm: () => removeMemberConfirmed(group, member)
+  })
+}
+
+onMounted(() => loadGroups())
+</script>
+
+<style scoped>
+.group-management {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.group-management-sidebar {
+  width: 340px;
+  min-width: 280px;
+  border-right: 1px solid var(--oc-color-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.group-management-sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--oc-space-small);
+  padding: var(--oc-space-medium);
+  border-bottom: 1px solid var(--oc-color-border);
+}
+
+.group-management-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--oc-space-small);
+}
+
+.group-management-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--oc-space-small);
+  border-radius: 5px;
+}
+
+.group-management-list-item.is-selected {
+  background-color: var(--oc-color-background-highlight);
+}
+
+.group-management-list-select {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--oc-space-xsmall);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: var(--oc-space-small);
+  text-align: left;
+  color: var(--oc-color-text-default);
+  min-width: 0;
+}
+
+.group-management-member-count {
+  margin-left: auto;
+  color: var(--oc-color-text-muted);
+  font-size: 0.875rem;
+}
+
+.group-management-readonly-badge {
+  font-size: 0.75rem;
+  color: var(--oc-color-text-muted);
+  padding-right: var(--oc-space-small);
+}
+
+.group-management-detail {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--oc-space-medium);
+}
+
+.group-management-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--oc-space-small);
+}
+
+.group-management-detail-actions {
+  display: flex;
+  gap: var(--oc-space-small);
+}
+
+.group-management-members-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--oc-space-small);
+  margin-bottom: var(--oc-space-small);
+}
+
+.group-management-member-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.group-management-member {
+  display: flex;
+  align-items: center;
+  gap: var(--oc-space-small);
+  padding: var(--oc-space-small) 0;
+  border-bottom: 1px solid var(--oc-color-border);
+}
+
+.group-management-member-name {
+  font-weight: 600;
+}
+
+.group-management-member-remove {
+  margin-left: auto;
+}
+
+.group-management-empty,
+.group-management-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--oc-space-medium);
+  height: 100%;
+  color: var(--oc-color-text-muted);
+  text-align: center;
+}
+
+.is-muted {
+  color: var(--oc-color-text-muted);
+}
+</style>

--- a/packages/web-app-group-management/src/views/GroupsView.vue
+++ b/packages/web-app-group-management/src/views/GroupsView.vue
@@ -161,8 +161,9 @@ const loadGroups = async (search = '') => {
     }
   } catch (error) {
     console.error(error)
+    // Keep the previously loaded list visible: a transient refresh/search
+    // failure must not blank the whole UI and force a full page reload.
     showErrorMessage({ title: $gettext('Failed to load groups'), errors: [error] })
-    groups.value = []
   } finally {
     loading.value = false
   }
@@ -178,11 +179,24 @@ const onSearch = () => {
 const selectGroup = async (id: string) => {
   selectedGroupId.value = id
   // The list endpoint returns a lightweight projection; fetch the full group
-  // (description + members) for the detail panel.
+  // (members) for the detail panel.
   try {
-    upsertGroup(await getGroup(id))
+    const full = await getGroup(id)
+    // A later click may have superseded this selection while the fetch was in
+    // flight; if so, discard this stale response so the panel keeps showing the
+    // group the user last clicked rather than snapping back to this one.
+    if (unref(selectedGroupId) !== id) {
+      return
+    }
+    upsertGroup(full)
   } catch (error) {
     console.error(error)
+    // Ignore the error of a selection the user has already moved away from.
+    if (unref(selectedGroupId) !== id) {
+      return
+    }
+    // Surface the failure rather than silently leaving the panel half-populated.
+    showErrorMessage({ title: $gettext('Failed to load group details'), errors: [error] })
   }
 }
 
@@ -259,20 +273,37 @@ const openDeleteGroup = (group: Group) => {
 const removeMemberConfirmed = async (group: Group, member: User) => {
   try {
     await removeMember(group.id, member.id)
-    showMessage({
-      title: $gettext('"%{member}" was removed from "%{group}"', {
-        member: member.displayName,
-        group: group.displayName
-      })
-    })
-    const updated = await getGroup(group.id)
-    upsertGroup(updated)
   } catch (error) {
     console.error(error)
     showErrorMessage({
       title: $gettext('Failed to remove "%{member}"', { member: member.displayName }),
       errors: [error]
     })
+    return
+  }
+
+  // Removal succeeded: confirm now. The re-fetch below is best-effort and must
+  // not turn a successful removal into a contradictory error toast.
+  showMessage({
+    title: $gettext('"%{member}" was removed from "%{group}"', {
+      member: member.displayName,
+      group: group.displayName
+    })
+  })
+
+  try {
+    upsertGroup(await getGroup(group.id))
+  } catch (error) {
+    console.error(error)
+    // Re-fetch failed; reflect the removal locally so the member list updates
+    // without a misleading error (it refreshes fully on the next load).
+    const current = unref(groups).find((g) => g.id === group.id)
+    if (current) {
+      upsertGroup({
+        ...current,
+        members: (current.members ?? []).filter((m) => m.id !== member.id)
+      })
+    }
   }
 }
 

--- a/packages/web-app-group-management/tests/e2e/groupManagement.spec.ts
+++ b/packages/web-app-group-management/tests/e2e/groupManagement.spec.ts
@@ -1,0 +1,75 @@
+import { test, type Page, type APIRequestContext, expect } from '@playwright/test'
+import { createContext, closeContext } from '../../../../support/helpers/actorHelper'
+import { LoginPage } from '../../../../support/pages/loginPage'
+import { GroupManagementPage } from '../../../../support/pages/groupManagementPage'
+
+const TEST_GROUP = 'e2e group management'
+
+let adminPage: Page
+
+/** Remove the test group via the Graph API so runs stay idempotent. */
+async function deleteTestGroup(request: APIRequestContext): Promise<void> {
+  const auth = Buffer.from('admin:admin').toString('base64')
+  const res = await request.get('/graph/v1.0/groups', {
+    headers: { Authorization: `Basic ${auth}` }
+  })
+  if (!res.ok()) {
+    return
+  }
+  const body = (await res.json()) as { value?: Array<{ id: string; displayName: string }> }
+  for (const group of body.value ?? []) {
+    if (group.displayName === TEST_GROUP) {
+      await request.delete(`/graph/v1.0/groups/${group.id}`, {
+        headers: { Authorization: `Basic ${auth}` }
+      })
+    }
+  }
+}
+
+test.describe('Group Management', () => {
+  test.beforeEach(async ({ browser, request }) => {
+    const { page } = await createContext(browser)
+    const loginPage = new LoginPage(page)
+    await page.goto('/')
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().endsWith('logon') &&
+          resp.status() === 200 &&
+          resp.request().method() === 'POST'
+      ),
+      loginPage.login('admin', 'admin')
+    ])
+    adminPage = page
+    await deleteTestGroup(request)
+  })
+
+  test.afterEach(async ({ request }) => {
+    await deleteTestGroup(request)
+    const context = adminPage.context()
+    const loginPage = new LoginPage(adminPage)
+    await loginPage.logout()
+    await closeContext(context)
+  })
+
+  test('renders the group management app', async () => {
+    const groups = new GroupManagementPage(adminPage)
+    await groups.open()
+    await expect(groups.view).toBeVisible()
+    await expect(groups.createButton).toBeVisible()
+  })
+
+  test('creates a group, shows it in the list, then deletes it', async () => {
+    const groups = new GroupManagementPage(adminPage)
+    await groups.open()
+
+    await groups.createGroup(TEST_GROUP)
+    await expect(groups.groupRow(TEST_GROUP)).toBeVisible()
+
+    await groups.selectGroup(TEST_GROUP)
+    await expect(groups.detailHeading(TEST_GROUP)).toBeVisible()
+
+    await groups.deleteSelectedGroup()
+    await expect(groups.groupRow(TEST_GROUP)).toHaveCount(0)
+  })
+})

--- a/packages/web-app-group-management/tests/unit/GroupFormModal.spec.ts
+++ b/packages/web-app-group-management/tests/unit/GroupFormModal.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+vi.mock('vue3-gettext', () => ({
+  useGettext: () => ({
+    $gettext: (s: string, params?: Record<string, unknown>) =>
+      params ? s.replace(/%\{(\w+)\}/g, (_, k) => String(params[k] ?? '')) : s
+  })
+}))
+
+const showMessage = vi.fn()
+const showErrorMessage = vi.fn()
+vi.mock('@ownclouders/web-pkg', () => ({
+  useMessages: () => ({ showMessage, showErrorMessage })
+}))
+
+vi.mock('../../src/composables/useGroupManagement', () => ({
+  useGroupManagement: vi.fn()
+}))
+
+import GroupFormModal from '../../src/components/GroupFormModal.vue'
+import { useGroupManagement } from '../../src/composables/useGroupManagement'
+
+const api = {
+  createGroup: vi.fn().mockResolvedValue({ id: 'g-new', displayName: 'NewGroup' }),
+  editGroup: vi.fn().mockResolvedValue(undefined),
+  getGroup: vi.fn().mockResolvedValue({ id: 'g1', displayName: 'Renamed' })
+}
+
+const OcTextInputStub = {
+  props: ['modelValue', 'label', 'errorMessage'],
+  emits: ['update:modelValue'],
+  template:
+    '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+}
+
+function createWrapper(props: Record<string, unknown> = {}) {
+  return mount(GroupFormModal, {
+    props: { modal: {} as any, ...props },
+    global: { stubs: { OcTextInput: OcTextInputStub } }
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useGroupManagement).mockReturnValue(api as any)
+})
+
+describe('GroupFormModal', () => {
+  it('disables confirm while the name is empty (create mode)', () => {
+    const wrapper = createWrapper()
+    const emitted = wrapper.emitted('update:confirmDisabled')
+    expect(emitted?.at(-1)).toEqual([true])
+  })
+
+  it('enables confirm once a valid name is entered and creates the group', async () => {
+    const onSaved = vi.fn()
+    const created = { id: 'g-new', displayName: 'NewGroup', description: '' }
+    api.getGroup.mockResolvedValueOnce(created)
+    const wrapper = createWrapper({ onSaved })
+
+    await wrapper.find('#group-management-input-display-name').setValue('NewGroup')
+    expect(wrapper.emitted('update:confirmDisabled')?.at(-1)).toEqual([false])
+
+    await (wrapper.vm as any).onConfirm()
+    await flushPromises()
+
+    expect(api.createGroup).toHaveBeenCalledWith('NewGroup')
+    // create response is re-fetched for the canonical group (members)
+    expect(api.getGroup).toHaveBeenCalledWith('g-new')
+    expect(api.editGroup).not.toHaveBeenCalled()
+    expect(showMessage).toHaveBeenCalled()
+    expect(onSaved).toHaveBeenCalledWith(created)
+  })
+
+  it('renames an existing group and reports the refreshed group', async () => {
+    const onSaved = vi.fn()
+    const wrapper = createWrapper({
+      group: { id: 'g1', displayName: 'Old' },
+      onSaved
+    })
+
+    // edit mode starts valid (prefilled name)
+    expect(wrapper.emitted('update:confirmDisabled')?.at(-1)).toEqual([false])
+
+    await wrapper.find('#group-management-input-display-name').setValue('Renamed')
+    await (wrapper.vm as any).onConfirm()
+    await flushPromises()
+
+    expect(api.editGroup).toHaveBeenCalledWith('g1', 'Renamed')
+    expect(api.getGroup).toHaveBeenCalledWith('g1')
+    expect(api.createGroup).not.toHaveBeenCalled()
+    expect(onSaved).toHaveBeenCalledWith({ id: 'g1', displayName: 'Renamed' })
+  })
+
+  it('rejects and does not call the API when the name is invalid', async () => {
+    const wrapper = createWrapper()
+    await expect((wrapper.vm as any).onConfirm()).rejects.toBeUndefined()
+    expect(api.createGroup).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web-app-group-management/tests/unit/useGroupManagement.spec.ts
+++ b/packages/web-app-group-management/tests/unit/useGroupManagement.spec.ts
@@ -48,6 +48,15 @@ describe('useGroupManagement', () => {
       })
     })
 
+    it('escapes double quotes in the search term so a typed " cannot break the OData phrase', async () => {
+      await useGroupManagement().listGroups('a"b')
+      expect(graph.groups.listGroups).toHaveBeenCalledWith({
+        orderBy: ['displayName'],
+        expand: ['members'],
+        search: '"a\\"b"'
+      })
+    })
+
     it('returns an empty array when the client yields nothing', async () => {
       graph.groups.listGroups.mockResolvedValueOnce(null)
       expect(await useGroupManagement().listGroups()).toEqual([])
@@ -72,15 +81,23 @@ describe('useGroupManagement', () => {
   })
 
   describe('addMembers', () => {
-    it('skips users already in the group and reports success/failure per user', async () => {
+    it('dedups against fresh server membership (not the passed snapshot)', async () => {
+      // The snapshot has no members, but the server says u1 is already in the
+      // group; u1 must be skipped based on the live state fetched at call time.
+      graph.groups.getGroup.mockResolvedValueOnce({
+        id: 'g1',
+        displayName: 'G1',
+        members: [{ id: 'u1' }]
+      })
       graph.groups.addMember
         .mockResolvedValueOnce(undefined) // u2 succeeds
         .mockRejectedValueOnce(new Error('boom')) // u3 fails
 
-      const group = { id: 'g1', displayName: 'G1', members: [{ id: 'u1' }] } as any
+      const group = { id: 'g1', displayName: 'G1', members: [] } as any
       const result = await useGroupManagement().addMembers(group, ['u1', 'u2', 'u3'])
 
-      // u1 is already a member -> skipped
+      expect(graph.groups.getGroup).toHaveBeenCalledWith('g1', { expand: ['members'] })
+      // u1 is already a member on the server -> skipped
       expect(graph.groups.addMember).toHaveBeenCalledTimes(2)
       expect(graph.groups.addMember).toHaveBeenCalledWith('g1', 'u2')
       expect(graph.groups.addMember).toHaveBeenCalledWith('g1', 'u3')
@@ -89,6 +106,15 @@ describe('useGroupManagement', () => {
       expect(result.succeeded).toEqual(['u2'])
       expect(result.failed).toHaveLength(1)
       expect(result.failed[0].id).toBe('u3')
+    })
+
+    it('falls back to the passed snapshot for dedup when the refresh fails', async () => {
+      graph.groups.getGroup.mockRejectedValueOnce(new Error('refresh failed'))
+      const group = { id: 'g1', displayName: 'G1', members: [{ id: 'u1' }] } as any
+      await useGroupManagement().addMembers(group, ['u1', 'u2'])
+      // u1 from the snapshot is still skipped despite the refresh failure
+      expect(graph.groups.addMember).toHaveBeenCalledTimes(1)
+      expect(graph.groups.addMember).toHaveBeenCalledWith('g1', 'u2')
     })
 
     it('reports all as succeeded when none fail', async () => {

--- a/packages/web-app-group-management/tests/unit/useGroupManagement.spec.ts
+++ b/packages/web-app-group-management/tests/unit/useGroupManagement.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@ownclouders/web-pkg', () => ({
+  useClientService: vi.fn()
+}))
+
+import { useClientService } from '@ownclouders/web-pkg'
+import { useGroupManagement } from '../../src/composables/useGroupManagement'
+
+const makeGraph = () => ({
+  groups: {
+    listGroups: vi.fn().mockResolvedValue([]),
+    getGroup: vi.fn().mockResolvedValue({ id: 'g1', displayName: 'G1', members: [] }),
+    createGroup: vi.fn().mockResolvedValue({ id: 'g-new', displayName: 'New' }),
+    editGroup: vi.fn().mockResolvedValue(undefined),
+    deleteGroup: vi.fn().mockResolvedValue(undefined),
+    addMember: vi.fn().mockResolvedValue(undefined),
+    deleteMember: vi.fn().mockResolvedValue(undefined)
+  },
+  users: {
+    listUsers: vi.fn().mockResolvedValue([])
+  }
+})
+
+let graph: ReturnType<typeof makeGraph>
+
+beforeEach(() => {
+  graph = makeGraph()
+  vi.mocked(useClientService).mockReturnValue({ graphAuthenticated: graph } as any)
+})
+
+describe('useGroupManagement', () => {
+  describe('listGroups', () => {
+    it('requests groups ordered by name and expands members', async () => {
+      await useGroupManagement().listGroups()
+      expect(graph.groups.listGroups).toHaveBeenCalledWith({
+        orderBy: ['displayName'],
+        expand: ['members']
+      })
+    })
+
+    it('passes a quoted search term when given', async () => {
+      await useGroupManagement().listGroups('sales')
+      expect(graph.groups.listGroups).toHaveBeenCalledWith({
+        orderBy: ['displayName'],
+        expand: ['members'],
+        search: '"sales"'
+      })
+    })
+
+    it('returns an empty array when the client yields nothing', async () => {
+      graph.groups.listGroups.mockResolvedValueOnce(null)
+      expect(await useGroupManagement().listGroups()).toEqual([])
+    })
+  })
+
+  describe('group CRUD', () => {
+    it('creates a group with display name only (oCIS groups have no description)', async () => {
+      await useGroupManagement().createGroup('Marketing')
+      expect(graph.groups.createGroup).toHaveBeenCalledWith({ displayName: 'Marketing' })
+    })
+
+    it('renames a group', async () => {
+      await useGroupManagement().editGroup('g1', 'Renamed')
+      expect(graph.groups.editGroup).toHaveBeenCalledWith('g1', { displayName: 'Renamed' })
+    })
+
+    it('deletes a group', async () => {
+      await useGroupManagement().deleteGroup('g1')
+      expect(graph.groups.deleteGroup).toHaveBeenCalledWith('g1')
+    })
+  })
+
+  describe('addMembers', () => {
+    it('skips users already in the group and reports success/failure per user', async () => {
+      graph.groups.addMember
+        .mockResolvedValueOnce(undefined) // u2 succeeds
+        .mockRejectedValueOnce(new Error('boom')) // u3 fails
+
+      const group = { id: 'g1', displayName: 'G1', members: [{ id: 'u1' }] } as any
+      const result = await useGroupManagement().addMembers(group, ['u1', 'u2', 'u3'])
+
+      // u1 is already a member -> skipped
+      expect(graph.groups.addMember).toHaveBeenCalledTimes(2)
+      expect(graph.groups.addMember).toHaveBeenCalledWith('g1', 'u2')
+      expect(graph.groups.addMember).toHaveBeenCalledWith('g1', 'u3')
+      expect(graph.groups.addMember).not.toHaveBeenCalledWith('g1', 'u1')
+
+      expect(result.succeeded).toEqual(['u2'])
+      expect(result.failed).toHaveLength(1)
+      expect(result.failed[0].id).toBe('u3')
+    })
+
+    it('reports all as succeeded when none fail', async () => {
+      const group = { id: 'g1', displayName: 'G1', members: [] } as any
+      const result = await useGroupManagement().addMembers(group, ['u1', 'u2'])
+      expect(result.succeeded).toEqual(['u1', 'u2'])
+      expect(result.failed).toEqual([])
+    })
+  })
+
+  describe('removeMember', () => {
+    it('removes a user from a group', async () => {
+      await useGroupManagement().removeMember('g1', 'u1')
+      expect(graph.groups.deleteMember).toHaveBeenCalledWith('g1', 'u1')
+    })
+  })
+
+  describe('searchUsers', () => {
+    it('passes a quoted search term', async () => {
+      await useGroupManagement().searchUsers('bob')
+      expect(graph.users.listUsers).toHaveBeenCalledWith({
+        orderBy: ['displayName'],
+        search: '"bob"'
+      })
+    })
+  })
+
+  describe('helpers', () => {
+    it('flags ReadOnly groups', () => {
+      const { isReadOnly } = useGroupManagement()
+      expect(isReadOnly({ id: 'g1', groupTypes: ['ReadOnly'] } as any)).toBe(true)
+      expect(isReadOnly({ id: 'g2' } as any)).toBe(false)
+    })
+
+    it('counts members defensively', () => {
+      const { memberCount } = useGroupManagement()
+      expect(memberCount({ id: 'g1', members: [{ id: 'u1' }, { id: 'u2' }] } as any)).toBe(2)
+      expect(memberCount({ id: 'g2' } as any)).toBe(0)
+    })
+  })
+})

--- a/packages/web-app-group-management/tsconfig.json
+++ b/packages/web-app-group-management/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@ownclouders/tsconfig",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/packages/web-app-group-management/vite.config.ts
+++ b/packages/web-app-group-management/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@ownclouders/extension-sdk'
+
+export default defineConfig({
+  name: 'web-app-group-management',
+  server: {
+    port: 9732
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'group-management.js'
+      }
+    }
+  },
+  test: {
+    environment: 'happy-dom',
+    exclude: ['**/e2e/**']
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,31 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  packages/web-app-group-management:
+    dependencies:
+      '@ownclouders/web-client':
+        specifier: ^12.3.2
+        version: 12.3.2
+      '@ownclouders/web-pkg':
+        specifier: ^12.3.2
+        version: 12.3.2(@vue/compiler-sfc@3.5.35)(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3))
+    devDependencies:
+      '@ownclouders/extension-sdk':
+        specifier: ^12.3.2
+        version: 12.3.2(vite@7.3.2(@types/node@24.13.2)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
+      '@ownclouders/web-test-helpers':
+        specifier: ^12.3.2
+        version: 12.3.2(@ownclouders/web-pkg@12.3.2(@vue/compiler-sfc@3.5.35)(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(@vue/compiler-sfc@3.5.35)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.9.3)))(vue@3.5.35(typescript@5.9.3)))(pinia@3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(typescript@5.9.3)(vitest@4.1.7(@types/node@24.13.2)(happy-dom@20.9.0)(vite@7.3.2(@types/node@24.13.2)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0)))(vue@3.5.35(typescript@5.9.3))
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@5.9.3)
+      vue-router:
+        specifier: ^5.1.0
+        version: 5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.35(typescript@5.9.3)))(vite@7.3.2(@types/node@24.13.2)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
+      vue3-gettext:
+        specifier: ^2.4.0
+        version: 2.4.0(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@5.9.3))
+
   packages/web-app-importer:
     dependencies:
       '@ownclouders/web-client':

--- a/support/pages/groupManagementPage.ts
+++ b/support/pages/groupManagementPage.ts
@@ -1,0 +1,50 @@
+import { Locator, Page } from '@playwright/test'
+
+export class GroupManagementPage {
+  readonly page: Page
+  readonly view: Locator
+  readonly createButton: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.view = this.page.getByTestId('group-management-view')
+    this.createButton = this.page.getByTestId('group-management-create')
+  }
+
+  /** Navigate to the Group Management app and wait for it to render. */
+  async open(): Promise<void> {
+    await this.page.goto('/group-management')
+    await this.createButton.waitFor({ state: 'visible' })
+  }
+
+  groupRow(name: string): Locator {
+    return this.page.getByTestId('group-management-group-row').filter({ hasText: name })
+  }
+
+  detailHeading(name: string): Locator {
+    return this.view.getByRole('heading', { level: 2, name })
+  }
+
+  private dialog(): Locator {
+    return this.page.getByRole('dialog')
+  }
+
+  async createGroup(name: string): Promise<void> {
+    await this.createButton.click()
+    await this.dialog().waitFor({ state: 'visible' })
+    await this.page.locator('#group-management-input-display-name').fill(name)
+    await this.dialog().getByRole('button', { name: 'Create', exact: true }).click()
+    await this.groupRow(name).waitFor({ state: 'visible' })
+  }
+
+  async selectGroup(name: string): Promise<void> {
+    await this.groupRow(name).click()
+    await this.detailHeading(name).waitFor({ state: 'visible' })
+  }
+
+  async deleteSelectedGroup(): Promise<void> {
+    await this.view.getByRole('button', { name: 'Delete group' }).click()
+    await this.dialog().waitFor({ state: 'visible' })
+    await this.dialog().getByRole('button', { name: 'Delete', exact: true }).click()
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new full-app web extension, **Group Management** (`packages/web-app-group-management`),
for managing groups and their members from a single, focused screen. It registers an app-menu
entry and a route, and talks only to the public LibreGraph API through the oCIS web client, so it
needs no backend changes.

The view is a two-pane layout: a searchable list of groups on the left, and a detail panel on the
right showing the selected group's members with controls to add and remove them.

## What it does

- List groups (server-side search by name)
- Create a group
- Rename a group
- Delete a group (with confirmation)
- View a group's members
- Add users to a group via a searchable user picker (server-side user search)
- Remove a user from a group (with confirmation)
- Read-only groups (`groupTypes: ["ReadOnly"]`) are marked and their mutate actions disabled
- Success/failure feedback via the standard oCIS message toasts; bulk member adds report
  per-user success/failure (settled independently)

## Scope: what oCIS supports

The extension is deliberately scoped to what oCIS / LibreGraph actually models for groups. Two
capabilities a "complete" MS-Graph-style group manager might expect are **not** available and are
therefore intentionally absent:

- **Nested groups.** A group's `members` are always users (`User[]`); the web client's `addMember`
  only accepts a user reference and there is no group-in-group relationship in LibreGraph. So there
  is no group tree, no parent/child groups, and no circular-dependency handling — none of it would
  have anything to call.
- **Group description.** oCIS groups expose only `id`, `displayName` and `groupTypes`. The MS-Graph
  `description` field is not persisted by the backend (verified against a live instance), so the
  create/edit form does not offer it.

If oCIS gains these capabilities, the extension can be extended to match. This is noted in the
package README too.

## Implementation

- Built with `defineWebApplication` from `@ownclouders/web-pkg`; registers an `appMenuItem`
  extension plus a route rendering `GroupsView.vue`, mirroring the existing full-app extensions
  (e.g. photo-addon).
- All group/member operations go through `clientService.graphAuthenticated.groups` / `.users`.
- Dialogs use the imperative oCIS modal service (`useModals().dispatchModal`): simple confirmations
  for delete/remove, and custom-component modals (`GroupFormModal`, `AddMembersModal`) that expose
  `onConfirm` and drive the confirm button via `update:confirmDisabled`.
- The user picker is an `oc-select` with server-side `$search` and an identity `:filter` so results
  are not re-filtered client-side (which would hide users matched by mail/username).
- The group list is a lightweight projection; selecting a group fetches the full group on demand.

## Testing

- **Unit:** `pnpm --filter ./packages/web-app-group-management test:unit` — 16 tests covering the
  graph composable (CRUD, member add/remove with per-user settle, ReadOnly/member-count helpers,
  search-term quoting) and the form modal (validation, create vs rename, confirm-disabled wiring).
- **e2e:** a smoke spec (`tests/e2e/groupManagement.spec.ts`) logs in, loads the app, and
  creates/selects/deletes a group, with Graph-API cleanup for idempotency.
- `pnpm --filter ./packages/web-app-group-management build` and `check:types` pass; repo `lint` is
  clean for the new files.
- Verified live against a local oCIS dev stack with the extension mounted: created a group, added a
  user member via the picker, and confirmed list/detail/member-count updates and toasts.
- Wired into the CI build/test matrix (`.github/workflows/test.yml`) and the dev `docker-compose.yml`.

## Risk

Low. New, self-contained package; no changes to shared code or other extensions. The only edits
outside the package are additive: a CI matrix entry, a dev-compose mount line, the lockfile, and a
shared e2e page object.