### PR TITLE
test(group-management): [OCISDEV-995] fix flaky e2e by waiting for OIDC callback to settle

### DIFF
--- a/packages/web-app-group-management/tests/e2e/groupManagement.spec.ts
+++ b/packages/web-app-group-management/tests/e2e/groupManagement.spec.ts
@@ -1,6 +1,5 @@
 import { test, type Page, type APIRequestContext, expect } from '@playwright/test'
-import { createContext, closeContext } from '../../../../support/helpers/actorHelper'
-import { LoginPage } from '../../../../support/pages/loginPage'
+import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
 import { GroupManagementPage } from '../../../../support/pages/groupManagementPage'
 
 const TEST_GROUP = 'e2e group management'
@@ -28,28 +27,14 @@ async function deleteTestGroup(request: APIRequestContext): Promise<void> {
 
 test.describe('Group Management', () => {
   test.beforeEach(async ({ browser, request }) => {
-    const { page } = await createContext(browser)
-    const loginPage = new LoginPage(page)
-    await page.goto('/')
-    await Promise.all([
-      page.waitForResponse(
-        (resp) =>
-          resp.url().endsWith('logon') &&
-          resp.status() === 200 &&
-          resp.request().method() === 'POST'
-      ),
-      loginPage.login('admin', 'admin')
-    ])
+    const { page } = await loginAsUser(browser, 'admin', 'admin')
     adminPage = page
     await deleteTestGroup(request)
   })
 
   test.afterEach(async ({ request }) => {
     await deleteTestGroup(request)
-    const context = adminPage.context()
-    const loginPage = new LoginPage(adminPage)
-    await loginPage.logout()
-    await closeContext(context)
+    await logout(adminPage)
   })
 
   test('renders the group management app', async () => {

--- a/support/helpers/authHelper.ts
+++ b/support/helpers/authHelper.ts
@@ -18,6 +18,9 @@ export async function loginAsUser(
     ),
     loginPage.login(username, password)
   ])
+  // Wait for the OIDC callback to fully complete so callers can safely call
+  // page.goto() without racing against the in-flight redirect.
+  await loginPage.myAccount.waitFor({ state: 'visible', timeout: 30000 })
   return { page }
 }
 


### PR DESCRIPTION
## Summary

- `loginAsUser()` in `authHelper.ts` now waits for the My Account button to be visible after login, confirming the OIDC redirect has fully completed before returning
- `groupManagement.spec.ts` refactored to use `loginAsUser`/`logout` from `authHelper.ts` instead of inlining the login sequence — so the fix lives in one place

## Root cause

After the `logon` POST returns 200, the browser still follows an in-flight redirect to `/web-oidc-callback` (or `/oidc-callback.html`). The previous `beforeEach` returned as soon as that response arrived, so the subsequent `page.goto('/group-management')` raced against the OIDC redirect and was intermittently interrupted.

## Test plan

- [x] Run `pnpm --filter group-management test:e2e` — all 6 tests (chrome, firefox, webkit × 2 scenarios) pass
- [x] Verify no other e2e suite is broken (the `authHelper.ts` change applies to all callers of `loginAsUser`)

Closes #473