### PR TITLE
test(e2e): [OCISDEV-1009] fix webkit race in PDF test cleanup

### DIFF
--- a/support/pages/filesAppBarActions.ts
+++ b/support/pages/filesAppBarActions.ts
@@ -21,13 +21,19 @@ export class FilesAppBar {
   async uploadFile(file: string) {
     await this.uploadBtn.click()
     const realPath = fileURLToPath(new URL(`../filesForUpload/${file}`, import.meta.url))
+    const replaceBtn = this.page.getByRole('button', { name: 'Replace' })
     await Promise.all([
       this.page.waitForResponse(
         (resp) =>
           [201, 204].includes(resp.status()) &&
           ['POST', 'PUT', 'PATCH'].includes(resp.request().method())
       ),
-      this.uploadFileBtn.setInputFiles(realPath)
+      (async () => {
+        await this.uploadFileBtn.setInputFiles(realPath)
+        if (await replaceBtn.isVisible()) {
+          await replaceBtn.click()
+        }
+      })()
     ])
     await this.closeUploadDialogBtn.click()
     await expect(this.newResourceContextMenu).not.toBeVisible()

--- a/support/pages/filesPage.ts
+++ b/support/pages/filesPage.ts
@@ -61,6 +61,7 @@ export class FilesPage {
     if (await sidebarCloseBtn.isVisible()) {
       await sidebarCloseBtn.click()
     }
+    await this.page.locator('.has-item-context-menu tr').first().waitFor({ state: 'visible' })
     await this.selectAllCheckbox.check()
     await this.deleteBtn.click()
   }


### PR DESCRIPTION
## Summary

- After navigating back to Files via the app switcher, webkit hadn't finished rendering the file list before `selectAllCheckbox.check()` ran — an empty list means the checkbox state never changes. Fixed by waiting for the first file row to be visible before selecting all.
- If a previous run's cleanup was interrupted, `test-document.pdf` could remain on the server. On retry, `uploadFile` would hit a "File already exists" conflict dialog that blocked `waitForResponse` indefinitely. Fixed by checking for the Replace button immediately after `setInputFiles` and clicking it if present.

## Test plan

- [ ] Confirm the `[webkit] › chatWithFile.spec.ts:65:1 › Edit mode pill is disabled for PDF files` test passes on CI
- [ ] Confirm all other chat-with-file e2e tests still pass across all three browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)