### PR TITLE
fix(ai-llm-proxy): enforce server-side Origin check (403 on mismatch)

### DIFF
--- a/packages/ai-llm-proxy/src/index.ts
+++ b/packages/ai-llm-proxy/src/index.ts
@@ -8,6 +8,20 @@ const PORT = parseInt(process.env.PORT ?? '3030', 10)
 const LLM_ENDPOINT = (process.env.LLM_ENDPOINT ?? '').replace(/\/$/, '')
 const LLM_API_KEY = process.env.LLM_API_KEY ?? ''
 const OCIS_URL = (process.env.OCIS_URL ?? '').replace(/\/$/, '')
+/**
+ * Origin (scheme://host:port) permitted to call the proxy, derived from
+ * OCIS_URL. Empty when OCIS_URL is unset or unparseable, in which case the
+ * origin gate cannot be enforced (the server refuses to start without
+ * OCIS_URL outside tests, so this only matters in unit tests).
+ */
+const ALLOWED_ORIGIN = (() => {
+  if (!OCIS_URL) return ''
+  try {
+    return new URL(OCIS_URL).origin
+  } catch {
+    return ''
+  }
+})()
 /** When set, overrides the model field sent by the client. */
 const LLM_MODEL = process.env.LLM_MODEL ?? ''
 /** Hard ceiling on max_tokens forwarded to the LLM (default 4 096). */
@@ -167,6 +181,32 @@ function setCorsHeaders(res: http.ServerResponse): void {
   res.setHeader('Access-Control-Max-Age', '86400')
 }
 
+/**
+ * Authoritative server-side origin check.
+ *
+ * CORS response headers (set by `setCorsHeaders`) are advisory and enforced
+ * only by the browser, so they cannot stop a non-browser or hostile client
+ * from reaching the LLM. This is the server-side gate that actually rejects
+ * requests from an unexpected origin.
+ *
+ * A cross-origin browser request always carries an `Origin` header (and so
+ * does a same-origin non-GET request, which is what the oCIS web extensions
+ * issue), so a genuine call from the oCIS UI always presents
+ * `Origin: <OCIS_URL origin>`. Any other present origin is a cross-site
+ * request and is rejected. A request with no `Origin` header cannot be a
+ * cross-site browser request and is still gated by the mandatory oCIS bearer
+ * token, so it is allowed through to token validation.
+ *
+ * @param origin   the incoming request's `Origin` header value, if any
+ * @param expected the allowed origin (scheme://host:port); empty disables the check
+ * @returns true when the request may proceed
+ */
+export function isOriginAllowed(origin: string | undefined, expected: string): boolean {
+  if (!expected) return true
+  if (origin !== undefined && origin !== expected) return false
+  return true
+}
+
 function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body)
   res.writeHead(status, { 'Content-Type': 'application/json' })
@@ -190,6 +230,15 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
   // Only POST /v1/chat/completions
   if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
     sendJson(res, 404, { error: 'Not found' })
+    return
+  }
+
+  // Authoritative server-side origin check (CORS headers above are advisory).
+  // Reject cross-site requests before doing any work.
+  const originHeader = req.headers['origin']
+  const origin = Array.isArray(originHeader) ? originHeader[0] : originHeader
+  if (!isOriginAllowed(origin, ALLOWED_ORIGIN)) {
+    sendJson(res, 403, { error: 'Origin not allowed' })
     return
   }
 

--- a/packages/ai-llm-proxy/tests/unit/proxy.spec.ts
+++ b/packages/ai-llm-proxy/tests/unit/proxy.spec.ts
@@ -7,7 +7,8 @@ import {
   checkRateLimit,
   rateLimitWindows,
   readBody,
-  BodyTooLargeError
+  BodyTooLargeError,
+  isOriginAllowed
 } from '../../src/index.js'
 
 // ---------------------------------------------------------------------------
@@ -153,5 +154,38 @@ describe('readBody', () => {
     const req = makeStream(['a'.repeat(50)])
     const body = await readBody(req, 50)
     expect(body.length).toBe(50)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isOriginAllowed
+// ---------------------------------------------------------------------------
+
+describe('isOriginAllowed', () => {
+  const expected = 'https://cloud.example.test'
+
+  it('allows a request whose Origin matches the expected origin', () => {
+    expect(isOriginAllowed('https://cloud.example.test', expected)).toBe(true)
+  })
+
+  it('rejects a request from a different origin', () => {
+    expect(isOriginAllowed('https://evil.example.test', expected)).toBe(false)
+  })
+
+  it('rejects an origin that differs only by scheme', () => {
+    expect(isOriginAllowed('http://cloud.example.test', expected)).toBe(false)
+  })
+
+  it('rejects an origin that differs only by port', () => {
+    expect(isOriginAllowed('https://cloud.example.test:8443', expected)).toBe(false)
+  })
+
+  it('allows a request with no Origin header (non-browser client, still token-gated)', () => {
+    expect(isOriginAllowed(undefined, expected)).toBe(true)
+  })
+
+  it('does not enforce when no expected origin is configured', () => {
+    expect(isOriginAllowed('https://anything.example.test', '')).toBe(true)
+    expect(isOriginAllowed(undefined, '')).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

`ai-llm-proxy` validates the oCIS bearer token and sets CORS response headers, but has **no server-side `Origin` check**. CORS headers are advisory and enforced only by the browser, so they do not stop a non-browser or cross-site client from reaching the LLM. The repo security requirement is explicit: any LLM-calling path "must perform an explicit server-side origin check and return `403` for unexpected origins — CORS headers alone are browser-enforced and insufficient."

This came up while reviewing the new AI extensions (#475, #476, #477), which all correctly route through this proxy and rely on it being the single enforcement point — but the enforcement was missing.

## Fix

Add an authoritative server-side `Origin` gate in `handleRequest`, before token validation and the LLM call:
- `Origin` header present but not matching the origin derived from `OCIS_URL` → **403**.
- No `Origin` header → allowed through to token validation. A cross-site browser request always carries `Origin`, so a missing one cannot be a cross-site browser attack, and the mandatory oCIS bearer token still guards it.
- No-op when `OCIS_URL` is unset (the server already refuses to start without it outside tests).

The expected origin is computed once from `OCIS_URL` via `new URL(OCIS_URL).origin`, so it compares correctly against the scheme/host/port `Origin` header.

## Testing

- New `isOriginAllowed` unit tests: matching origin, cross origin, scheme mismatch, port mismatch, missing header, unconfigured.
- `pnpm --filter ai-llm-proxy test:unit` → **25 passed**.
- `pnpm --filter ai-llm-proxy build` + `lint` clean.

## Risk

Low. Genuine calls from the oCIS web extensions are same-origin POSTs that always carry `Origin: <OCIS_URL origin>`, so they are unaffected. Only requests from a different (or unexpected) origin are newly rejected — which is the intent.
