### PR TITLE
test(e2e): fix webkit race in upload bar close button

### DIFF
--- a/support/pages/filesAppBarActions.ts
+++ b/support/pages/filesAppBarActions.ts
@@ -35,7 +35,9 @@ export class FilesAppBar {
         }
       })()
     ])
-    await this.closeUploadDialogBtn.click()
+    if (await this.closeUploadDialogBtn.isVisible()) {
+      await this.closeUploadDialogBtn.click()
+    }
     await expect(this.newResourceContextMenu).not.toBeVisible()
     await expect(this.uploadResourceContextMenu).not.toBeVisible()
   }


### PR DESCRIPTION
## Summary

- In WebKit, the upload progress bar's close button (`#close-upload-bar-btn`) never becomes visible after a WebDAV upload completes — WebKit skips or auto-dismisses the progress UI before Playwright can interact with it
- `locator.click()` auto-waits for the element, hanging for the full 30s timeout and causing all `ai-image-alt-text-sidebar` webkit tests to fail in `beforeEach`
- Guard the click with `isVisible()`, matching the identical pattern already used in `filesPage.deleteAllFromPersonal()`; the upload is confirmed complete by `waitForResponse` so skipping the close click is safe

## Test plan

- [ ] Confirm `pnpm --filter web-app-ai-image-alt-text-sidebar test:e2e` passes on webkit in CI
- [ ] Confirm chromium/firefox tests remain green (no regression in other browsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)