### PR TITLE
fix(ai-data-insights-sidebar): fix flaky e2e tests on webkit

### DIFF
--- a/packages/web-app-ai-data-insights-sidebar/tests/e2e/acceptance.spec.ts
+++ b/packages/web-app-ai-data-insights-sidebar/tests/e2e/acceptance.spec.ts
@@ -12,6 +12,11 @@ test.beforeEach(async ({ browser }) => {
 })
 
 test.afterEach(async () => {
+  // Remove any route handlers registered during the test before the cleanup
+  // navigation. A request-interception handler left active across page.goto
+  // intermittently crashes webkit's network layer with "WebKit encountered an
+  // internal error"; the tests only need the mock while the panel is open.
+  await adminPage.unrouteAll({ behavior: 'ignoreErrors' })
   const filesPage = new FilesPage(adminPage)
   await filesPage.deleteAllFromPersonal()
   await logout(adminPage)

--- a/packages/web-app-ai-data-insights-sidebar/tests/e2e/pages/aiDataInsightsSidebarPage.ts
+++ b/packages/web-app-ai-data-insights-sidebar/tests/e2e/pages/aiDataInsightsSidebarPage.ts
@@ -56,7 +56,9 @@ export class AiDataInsightsSidebarPage {
       ),
       uploadInput.setInputFiles(fixturePath)
     ])
-    await closeBtn.click()
+    if (await closeBtn.isVisible()) {
+      await closeBtn.click()
+    }
     await expect(newFileMenuDrop).not.toBeVisible()
     await expect(uploadMenuDrop).not.toBeVisible()
     return 'sample.csv'


### PR DESCRIPTION
## Summary

The `clicking "Insights" opens the panel` test intermittently failed on webkit
with `page.goto: WebKit encountered an internal error` during the `afterEach`
cleanup navigation.

**Root cause:** the test registers a `page.route('**/ai-llm-proxy/**')`
interceptor that is never removed, so a live request-interception handler is
still attached to the page when `afterEach` calls
`page.goto('/files/spaces/personal')`. Navigating a webkit page with an active
route handler occasionally crashes its network layer. (The trace confirms the
mock is never even hit — the panel only renders on open; an LLM request fires
solely on a manual "Analyze" click, which the test never performs.)

**Fix:** tear the handler down with `page.unrouteAll()` at the start of
`afterEach`, before the navigation. The mock still guards the test body
(opening the panel never reaches a real LLM endpoint); it is only removed once
no longer needed.

Also guards the `#close-upload-bar-btn` click with an `isVisible()` check so
webkit doesn't crash when the upload bar auto-dismisses before the click fires.

## Test plan

- [x] Ran the `web-app-ai-data-insights-sidebar` E2E suite locally against a real
  oCIS on webkit — 10× full-suite repeat and 20× single-test repeat under CPU
  stress all passed; chrome passes too
- [x] Confirm no flaky timeouts on webkit in CI
