### PR TITLE
feat(ai-llm-proxy): make upstream LLM request timeout configurable

### DIFF
--- a/packages/ai-llm-proxy/src/index.ts
+++ b/packages/ai-llm-proxy/src/index.ts
@@ -30,6 +30,8 @@ const LLM_MAX_TOKENS = parseInt(process.env.LLM_MAX_TOKENS ?? '4096', 10)
 const MAX_BODY_BYTES = parseInt(process.env.MAX_BODY_BYTES ?? '6291456', 10)
 /** Maximum LLM requests per user per rolling minute (default 20). */
 const RATE_LIMIT_RPM = parseInt(process.env.RATE_LIMIT_RPM ?? '20', 10)
+/** Timeout for the upstream LLM request in milliseconds (default 60 000). */
+const LLM_TIMEOUT_MS = parseInt(process.env.LLM_TIMEOUT_MS ?? '60000', 10)
 
 // ---------------------------------------------------------------------------
 // OIDC discovery — lazily fetched on first request, userinfo_endpoint cached
@@ -306,7 +308,7 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
       method: 'POST',
       headers: llmHeaders,
       body: JSON.stringify(sanitized),
-      signal: AbortSignal.timeout(60_000)
+      signal: AbortSignal.timeout(LLM_TIMEOUT_MS)
     })
   } catch (err) {
     console.error('[ai-llm-proxy] LLM request error:', err)

--- a/packages/web-app-chat-with-file/README.md
+++ b/packages/web-app-chat-with-file/README.md
@@ -83,6 +83,7 @@ stays server-side and never reaches the browser:
 | `LLM_MAX_TOKENS` | no | Hard ceiling on `max_tokens` forwarded to the LLM (default `4096`) |
 | `MAX_BODY_BYTES` | no | Maximum request body the proxy will buffer in bytes (default `131072` = 128 KiB) |
 | `RATE_LIMIT_RPM` | no | Maximum LLM requests per authenticated user per rolling minute (default `20`) |
+| `LLM_TIMEOUT_MS` | no | Timeout for the upstream LLM request in milliseconds (default `60000`) |
 | `PORT` | no | Listening port, default `3030` |
 | `NODE_TLS_REJECT_UNAUTHORIZED` | no | Set to `0` for dev stacks with self-signed certs |
 


### PR DESCRIPTION
## Summary
- The `ai-llm-proxy` had a hardcoded 60s timeout on the upstream LLM request, which is too short for some slower LLMs/models.
- Added `LLM_TIMEOUT_MS` env var (default `60000`) so operators can tune it per deployment, following the existing config pattern (`LLM_MAX_TOKENS`, `MAX_BODY_BYTES`, `RATE_LIMIT_RPM`).
- Documented the new variable in `packages/web-app-chat-with-file/README.md`.

## Test plan
- [x] `pnpm --filter ai-llm-proxy test:unit` — 25/25 passing
- [x] Verified default behavior unchanged (defaults to 60000ms) when `LLM_TIMEOUT_MS` is unset