### PR TITLE
fix(web-app-ai-quick-draft-creator): improve new file action icon and label

### DIFF
--- a/packages/web-app-ai-quick-draft-creator/README.md
+++ b/packages/web-app-ai-quick-draft-creator/README.md
@@ -1,12 +1,12 @@
 # web-app-ai-quick-draft-creator
 
-Adds a **"Draft from description"** entry to the oCIS Files upload menu. A modal lets the user describe the document they need; an LLM generates a well-structured draft and saves it as a new file in the current folder.
+Adds a **"Generate a file with AI"** entry to the oCIS Files upload menu. A modal lets the user describe the document they need; an LLM generates a well-structured draft and saves it as a new file in the current folder.
 
 **Extension point:** `app.files.upload-menu`
 
 ## What it does
 
-1. The user clicks the upload menu in Files and selects **Draft from description**.
+1. The user clicks the upload menu in Files and selects **Generate a file with AI**.
 2. A modal prompts for a document description and an output format (Markdown or plain text).
 3. The extension calls the `ai-llm-proxy` (same-origin) which validates the user's oCIS OIDC token and proxies the request to the configured LLM.
 4. The generated draft is written to the current folder via WebDAV. Filenames include a timestamp suffix (`slug-YYYY-MM-DD-HH-mm-ss.ext`) so same-day drafts never overwrite each other.

--- a/packages/web-app-ai-quick-draft-creator/src/index.ts
+++ b/packages/web-app-ai-quick-draft-creator/src/index.ts
@@ -40,12 +40,12 @@ export default defineWebApplication({
       extensions: [
         {
           newFileMenu: {
-            menuTitle: () => $pgettext('New file menu item', 'Draft from description'),
+            menuTitle: () => $pgettext('New file menu item', 'Generate a file with AI'),
             isVisible: ({ currentFolder }) =>
               llmConfig !== null && !!(currentFolder?.canUpload({ user: userStore.user }))
           },
           customHandler: () => openModal(),
-          icon: 'draft'
+          icon: 'sparkling-2'
         }
       ]
     }

--- a/packages/web-app-ai-quick-draft-creator/tests/e2e/acceptance.spec.ts
+++ b/packages/web-app-ai-quick-draft-creator/tests/e2e/acceptance.spec.ts
@@ -3,7 +3,7 @@ import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
 
 const NEW_FILE_MENU_BTN = '#new-file-menu-btn'
 const NEW_FILE_MENU_DROP = '#new-file-menu-drop'
-const DRAFT_MENU_ITEM_TEXT = 'Draft from description'
+const DRAFT_MENU_ITEM_TEXT = 'Generate a file with AI'
 const DESCRIPTION_INPUT = '[data-testid="draft-description"]'
 const FORMAT_SELECT = '[data-testid="draft-format"]'
 const CREATE_BTN = '[data-testid="draft-create"]'
@@ -49,7 +49,7 @@ test.afterEach(async () => {
   await logout(adminPage)
 })
 
-test('"Draft from description" item appears in new file menu when LLM is configured', async () => {
+test('"Generate a file with AI" item appears in new file menu when LLM is configured', async () => {
   await openNewFileMenu(adminPage)
 
   const draftItem = adminPage.locator(NEW_FILE_MENU_DROP).getByText(DRAFT_MENU_ITEM_TEXT)


### PR DESCRIPTION
## Summary
- Changed the "New file" menu action icon from `draft` (a generic blank-document glyph indistinguishable from other file-type entries) to `sparkling-2`, matching the icon convention already used by every other AI extension in this repo (ai-folder-brief-sidebar, ai-data-insights-sidebar, ai-doc-summary, ai-folder-readme-generator, ai-multi-doc-synthesizer, ai-image-alt-text-sidebar, ai-smart-file-tagger-qa, ai-smart-collections-nav).
- Changed the menu label from "Draft from description" to "Generate a file with AI" so the entry clearly communicates it's an AI-powered feature, per the issue's own suggested wording.
- Updated the e2e test (`tests/e2e/acceptance.spec.ts`) and the package README to reference the new label so they stay in sync with the UI copy.

Before → After:
- icon: `'draft'` → `'sparkling-2'`
- label: `"Draft from description"` → `"Generate a file with AI"`

Closes #529

## Test plan
- [x] `pnpm --filter web-app-ai-quick-draft-creator check:types` passes
- [x] `pnpm --filter web-app-ai-quick-draft-creator lint` passes
- [x] `pnpm --filter web-app-ai-quick-draft-creator test:unit` passes (11/11)
- [x] Verified `sparkling-2` is the established AI-icon convention via grep across `packages/web-app-ai-*/src/index.ts`
- [x] Verified `sparkling-2-line.svg` / `sparkling-2-fill.svg` exist in the design system icon set