### PR TITLE
fix(web-app-ai-quick-draft-creator): reposition and differentiate draft creation error

### DIFF
--- a/packages/web-app-ai-quick-draft-creator/src/components/DraftCreatorModal.vue
+++ b/packages/web-app-ai-quick-draft-creator/src/components/DraftCreatorModal.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="draft-creator-modal">
-    <div v-if="error" class="draft-creator-modal__error oc-mt-s oc-text-error" role="alert">
-      {{ error }}
-    </div>
-
     <div class="oc-mb-m">
       <label class="oc-label" for="draft-description">
         {{ $gettext('Describe the document you need') }}
@@ -35,6 +31,10 @@
         <option value="markdown">{{ $gettext('Markdown') }}</option>
         <option value="plain">{{ $gettext('Plain text') }}</option>
       </select>
+    </div>
+
+    <div v-if="error" class="draft-creator-modal__error oc-mb-m" role="alert">
+      {{ error }}
     </div>
 
     <div class="draft-creator-modal__actions oc-flex oc-flex-right oc-mt-m">
@@ -94,3 +94,9 @@ async function handleCreate(): Promise<void> {
   }
 }
 </script>
+
+<style scoped>
+.draft-creator-modal__error {
+  color: var(--oc-color-danger, #c00);
+}
+</style>

--- a/packages/web-app-ai-quick-draft-creator/tests/unit/components/DraftCreatorModal.spec.ts
+++ b/packages/web-app-ai-quick-draft-creator/tests/unit/components/DraftCreatorModal.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import DraftCreatorModal from '../../../src/components/DraftCreatorModal.vue'
+
+vi.mock('../../../src/composables/useDraftCreator')
+
+vi.mock('vue3-gettext', () => ({
+  useGettext: () => ({
+    $gettext: (s: string) => s,
+    $pgettext: (_context: string, s: string) => s
+  })
+}))
+
+vi.mock('@ownclouders/web-pkg', () => ({
+  useFileActions: () => ({ triggerDefaultAction: vi.fn() })
+}))
+
+import { useDraftCreator } from '../../../src/composables/useDraftCreator.js'
+import type { CreatedDraft, DraftFormat } from '../../../src/composables/useDraftCreator.js'
+import type { LLMConfig } from '../../../src/composables/useLLM.js'
+
+const createDraftMock = vi.fn()
+
+function setupUseDraftCreatorMock({
+  creating = false,
+  error = null as string | null
+} = {}) {
+  vi.mocked(useDraftCreator).mockReturnValue({
+    creating: ref(creating),
+    error: ref(error),
+    canCreate: vi.fn().mockReturnValue(true),
+    createDraft: createDraftMock
+  })
+}
+
+function createWrapper(props: { llmConfig?: LLMConfig | null } = {}) {
+  return mount(DraftCreatorModal, {
+    props: {
+      llmConfig: null,
+      ...props
+    }
+  })
+}
+
+describe('DraftCreatorModal', () => {
+  beforeEach(() => {
+    createDraftMock.mockReset().mockResolvedValue(null as unknown as CreatedDraft | null)
+    setupUseDraftCreatorMock()
+  })
+
+  describe('error state', () => {
+    it('does not show an error banner when there is no error', async () => {
+      setupUseDraftCreatorMock({ error: null })
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('.draft-creator-modal__error').exists()).toBe(false)
+    })
+
+    it('shows the error message returned by the composable', async () => {
+      setupUseDraftCreatorMock({ error: 'signal timed out' })
+      const wrapper = createWrapper()
+      await flushPromises()
+      const banner = wrapper.find('.draft-creator-modal__error')
+      expect(banner.exists()).toBe(true)
+      expect(banner.text()).toBe('signal timed out')
+    })
+
+    it('assigns role="alert" to the error element', async () => {
+      setupUseDraftCreatorMock({ error: 'signal timed out' })
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.find('[role="alert"]').exists()).toBe(true)
+    })
+
+    it('renders the error after the description and format fields, and before the actions', async () => {
+      setupUseDraftCreatorMock({ error: 'signal timed out' })
+      const wrapper = createWrapper()
+      await flushPromises()
+
+      const children = Array.from(wrapper.element.children) as Element[]
+      const descriptionIndex = children.findIndex((el) =>
+        el.querySelector('[data-testid="draft-description"]')
+      )
+      const errorIndex = children.findIndex((el) => el.classList.contains('draft-creator-modal__error'))
+      const actionsIndex = children.findIndex((el) =>
+        el.classList.contains('draft-creator-modal__actions')
+      )
+
+      expect(descriptionIndex).toBeGreaterThanOrEqual(0)
+      expect(errorIndex).toBeGreaterThan(descriptionIndex)
+      expect(actionsIndex).toBeGreaterThan(errorIndex)
+    })
+  })
+
+  describe('create draft', () => {
+    it('calls createDraft with the trimmed description and selected format', async () => {
+      setupUseDraftCreatorMock()
+      const wrapper = createWrapper()
+      await flushPromises()
+
+      await wrapper.find('[data-testid="draft-description"]').setValue('  A budget review  ')
+      await wrapper.find<HTMLButtonElement>('[data-testid="draft-create"]').trigger('click')
+      await flushPromises()
+
+      expect(createDraftMock).toHaveBeenCalledWith('A budget review', 'markdown' as DraftFormat)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Moves the draft-creation error banner in `DraftCreatorModal.vue` from above the description textarea to just above the action buttons, next to the "Create draft" action that can actually fail.
- Replaces the unstyled `oc-text-error` utility class with a scoped style using `var(--oc-color-danger, #c00)`, matching the convention already used in sibling packages (`web-app-ai-sensitive-data-scanner`'s `.scan-results-error`, `web-app-ai-smart-file-tagger-qa`'s `.tag-suggestion-error`, `web-app-ai-multi-doc-synthesizer`'s `.synthesis-error`).
- Keeps `role="alert"` for accessibility and does not change any error messages or the error-setting logic in `useDraftCreator.ts`.
- Adds `tests/unit/components/DraftCreatorModal.spec.ts` covering: no banner when there's no error, banner text/role when there is one, correct DOM ordering (after the description/format fields, before the actions), and the existing create-draft happy path.

### Before
Error text ("signal timed out") rendered as the very first element in the modal, above the "Describe the document you need" label, in the same plain body-text styling as the rest of the content.

### After
Error text renders directly above the Cancel/Create draft buttons, styled in the design system's danger color so it's clearly distinguishable from body copy.

Closes #528

## Test plan
- [x] `pnpm --filter web-app-ai-quick-draft-creator check:types`
- [x] `pnpm --filter web-app-ai-quick-draft-creator lint`
- [x] `pnpm --filter web-app-ai-quick-draft-creator test:unit` (16 passed, including 5 new)