### PR TITLE
fix(ai-llm-proxy): prevent mid-flight request cancellation from wasting LLM cost

### DIFF
--- a/packages/ai-llm-proxy/src/index.ts
+++ b/packages/ai-llm-proxy/src/index.ts
@@ -209,7 +209,15 @@ export function isOriginAllowed(origin: string | undefined, expected: string): b
   return true
 }
 
+/**
+ * Writes a JSON response, but no-ops when the client has already
+ * disconnected (`res.writableEnded`/`res.destroyed`) — writing to a response
+ * whose underlying socket is gone can emit an 'error' event on `res`, which
+ * would crash the process without a listener. See the `res.on('error', ...)`
+ * guard in `handleRequest` for the belt-and-suspenders backstop.
+ */
 function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  if (res.writableEnded || res.destroyed) return
   const payload = JSON.stringify(body)
   res.writeHead(status, { 'Content-Type': 'application/json' })
   res.end(payload)
@@ -219,7 +227,27 @@ function sendJson(res: http.ServerResponse, status: number, body: unknown): void
 // Request handler
 // ---------------------------------------------------------------------------
 
-async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+export async function handleRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+): Promise<void> {
+  // Defensive: once the client has disconnected (see the 'close' listener
+  // below), writing to `res` can emit an 'error' event on the response
+  // stream. Without a listener, an unhandled 'error' event on a stream
+  // crashes the whole process, so this is a no-op safety net regardless of
+  // where a write happens below.
+  res.on('error', () => {})
+
+  // Tracks whether the client is still there to receive a response, and
+  // lets us abort the outbound LLM fetch the moment it isn't. Node emits
+  // 'close' on the request once the underlying connection is terminated —
+  // whether that's a clean end, the client's own AbortSignal.timeout firing,
+  // or the tab/browser dropping the connection — so this is the one signal
+  // we need to stop doing (and paying for) work nobody will receive the
+  // result of.
+  const clientAbortController = new AbortController()
+  req.on('close', () => clientAbortController.abort())
+
   setCorsHeaders(res)
 
   // Preflight
@@ -304,11 +332,15 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
 
   let llmRes: Response
   try {
+    // Two independent reasons to give up on the outbound LLM call: it's
+    // taking too long (upstream timeout), or the client that asked for it
+    // is no longer there (clientAbortController, aborted from the 'close'
+    // listener above). Either one should stop the request.
     llmRes = await fetch(`${LLM_ENDPOINT}/chat/completions`, {
       method: 'POST',
       headers: llmHeaders,
       body: JSON.stringify(sanitized),
-      signal: AbortSignal.timeout(LLM_TIMEOUT_MS)
+      signal: AbortSignal.any([clientAbortController.signal, AbortSignal.timeout(LLM_TIMEOUT_MS)])
     })
   } catch (err) {
     console.error('[ai-llm-proxy] LLM request error:', err)
@@ -317,6 +349,7 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
   }
 
   const llmBody = await llmRes.text()
+  if (res.writableEnded || res.destroyed) return
   res.writeHead(llmRes.status, {
     'Content-Type': llmRes.headers.get('content-type') ?? 'application/json'
   })

--- a/packages/ai-llm-proxy/tests/unit/proxy.spec.ts
+++ b/packages/ai-llm-proxy/tests/unit/proxy.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { Readable } from 'node:stream'
+import { EventEmitter } from 'node:events'
 import type http from 'node:http'
 
 import {
@@ -8,7 +9,8 @@ import {
   rateLimitWindows,
   readBody,
   BodyTooLargeError,
-  isOriginAllowed
+  isOriginAllowed,
+  handleRequest
 } from '../../src/index.js'
 
 // ---------------------------------------------------------------------------
@@ -187,5 +189,212 @@ describe('isOriginAllowed', () => {
   it('does not enforce when no expected origin is configured', () => {
     expect(isOriginAllowed('https://anything.example.test', '')).toBe(true)
     expect(isOriginAllowed(undefined, '')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleRequest — client-disconnect aborts the outbound LLM fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal http.IncomingMessage double: an EventEmitter carrying the
+ * headers/method/url handleRequest reads, plus manual 'data'/'end'/'close'
+ * emission so tests can drive the request lifecycle explicitly (a real
+ * Readable's autoDestroy would fire 'close' right after 'end', which would
+ * defeat the point of testing 'close' as a distinct disconnect signal).
+ */
+function makeMockReq(overrides: Partial<http.IncomingMessage> = {}): http.IncomingMessage {
+  const req = new EventEmitter() as unknown as http.IncomingMessage
+  Object.assign(req, {
+    method: 'POST',
+    url: '/v1/chat/completions',
+    headers: { authorization: 'Bearer test-token' },
+    ...overrides
+  })
+  return req
+}
+
+/**
+ * A minimal http.ServerResponse double. `writableEnded`/`destroyed` mirror
+ * the real flags `sendJson`/`handleRequest` check before writing; `end`
+ * flips `writableEnded` the way a real response would.
+ */
+function makeMockRes(): http.ServerResponse & { writeHead: ReturnType<typeof vi.fn> } {
+  const res = new EventEmitter() as unknown as http.ServerResponse & {
+    writeHead: ReturnType<typeof vi.fn>
+  }
+  Object.assign(res, {
+    statusCode: 200,
+    headersSent: false,
+    writableEnded: false,
+    destroyed: false,
+    setHeader: vi.fn(),
+    writeHead: vi.fn(),
+    write: vi.fn(),
+    end: vi.fn(function end(this: typeof res) {
+      this.writableEnded = true
+    })
+  })
+  return res
+}
+
+/** Emulates fetch's real abort semantics: rejects once the signal aborts. */
+function pendingUntilAborted(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener('abort', () => {
+      const err = new Error('This operation was aborted')
+      err.name = 'AbortError'
+      reject(err)
+    })
+  })
+}
+
+/**
+ * handleRequest awaits two OIDC round-trips (discovery + userinfo) before it
+ * ever calls `readBody`, which is what attaches the 'data'/'end' listeners
+ * `req.emit(...)` needs a live listener for. Polling for the listener
+ * (rather than guessing a fixed number of microtask ticks) keeps the test
+ * from being coupled to handleRequest's exact internal await count.
+ */
+function waitForListener(emitter: EventEmitter, event: string): Promise<void> {
+  return new Promise((resolve) => {
+    const check = () => {
+      if (emitter.listenerCount(event) > 0) {
+        resolve()
+      } else {
+        setImmediate(check)
+      }
+    }
+    check()
+  })
+}
+
+describe('handleRequest — aborts the upstream LLM fetch on client disconnect', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    rateLimitWindows.clear()
+  })
+
+  it('aborts the outbound fetch signal when the client closes the connection mid-flight', async () => {
+    let capturedSignal: AbortSignal | undefined
+    let chatCompletionsCalled = false
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url.includes('.well-known/openid-configuration')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ userinfo_endpoint: 'https://ocis.example.test/userinfo' })
+          })
+        }
+        if (url.includes('/userinfo')) {
+          return Promise.resolve({ ok: true, json: async () => ({ sub: 'user-close-test' }) })
+        }
+        if (url.includes('/chat/completions')) {
+          capturedSignal = init?.signal as AbortSignal
+          chatCompletionsCalled = true
+          return pendingUntilAborted(capturedSignal)
+        }
+        return Promise.reject(new Error(`unexpected fetch url: ${url}`))
+      })
+    )
+
+    const req = makeMockReq()
+    const res = makeMockRes()
+
+    const pending = handleRequest(req, res)
+
+    // handleRequest awaits OIDC discovery + userinfo before it ever attaches
+    // the body listeners, so wait for readBody's 'data' listener before
+    // emitting the body.
+    await waitForListener(req, 'data')
+    req.emit('data', Buffer.from(JSON.stringify({ model: 'test-model', messages: [] })))
+    req.emit('end')
+
+    // Wait until the outbound LLM fetch has actually been issued, then
+    // simulate the client disconnecting while it's still in flight.
+    await vi.waitFor(() => {
+      if (!chatCompletionsCalled) throw new Error('chat/completions not called yet')
+    })
+    req.emit('close')
+
+    await pending
+
+    expect(capturedSignal).toBeDefined()
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+
+  it('does not attempt to write to the response once the client has disconnected', async () => {
+    let chatCompletionsCalled = false
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url.includes('.well-known/openid-configuration')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ userinfo_endpoint: 'https://ocis.example.test/userinfo' })
+          })
+        }
+        if (url.includes('/userinfo')) {
+          return Promise.resolve({ ok: true, json: async () => ({ sub: 'user-write-test' }) })
+        }
+        if (url.includes('/chat/completions')) {
+          chatCompletionsCalled = true
+          return pendingUntilAborted(init?.signal as AbortSignal)
+        }
+        return Promise.reject(new Error(`unexpected fetch url: ${url}`))
+      })
+    )
+
+    const req = makeMockReq()
+    const res = makeMockRes()
+
+    const pending = handleRequest(req, res)
+
+    await waitForListener(req, 'data')
+    req.emit('data', Buffer.from(JSON.stringify({ model: 'test-model', messages: [] })))
+    req.emit('end')
+
+    await vi.waitFor(() => {
+      if (!chatCompletionsCalled) throw new Error('chat/completions not called yet')
+    })
+
+    // The client's socket is gone: mark the response as no longer writable
+    // (mirrors what happens to a real http.ServerResponse sharing the same
+    // dead connection) and signal the disconnect.
+    res.writableEnded = true
+    res.destroyed = true
+    req.emit('close')
+
+    // Should resolve cleanly — no unhandled rejection/exception — and must
+    // not have attempted to write the 502 "Could not reach LLM endpoint"
+    // fallback to a response nobody can receive.
+    await expect(pending).resolves.toBeUndefined()
+    expect(res.writeHead).not.toHaveBeenCalled()
+    expect(res.end).not.toHaveBeenCalled()
+  })
+
+  it('attaches an error listener to the response, so a late write-after-close error cannot crash the process', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        // Fails fast (missing auth header) so handleRequest returns quickly
+        // — this test only cares about the defensive res.on('error') guard
+        // that's installed unconditionally at the top of handleRequest.
+        return Promise.reject(new Error(`unexpected fetch url: ${url}`))
+      })
+    )
+
+    const req = makeMockReq({ headers: {} })
+    const res = makeMockRes()
+
+    await handleRequest(req, res)
+
+    // Node's EventEmitter throws synchronously when 'error' is emitted with
+    // no listener attached — asserting this does NOT throw proves
+    // handleRequest's `res.on('error', () => {})` guard is in place.
+    expect(() => res.emit('error', new Error('write after close'))).not.toThrow()
   })
 })

--- a/packages/web-app-ai-data-insights-sidebar/src/composables/useLLM.ts
+++ b/packages/web-app-ai-data-insights-sidebar/src/composables/useLLM.ts
@@ -55,8 +55,10 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,

--- a/packages/web-app-ai-data-insights-sidebar/src/composables/useLLM.ts
+++ b/packages/web-app-ai-data-insights-sidebar/src/composables/useLLM.ts
@@ -55,7 +55,8 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(60_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,

--- a/packages/web-app-ai-doc-summary/src/composables/useSummary.ts
+++ b/packages/web-app-ai-doc-summary/src/composables/useSummary.ts
@@ -147,7 +147,8 @@ export function useSummary(
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(30_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages: [

--- a/packages/web-app-ai-doc-summary/src/composables/useSummary.ts
+++ b/packages/web-app-ai-doc-summary/src/composables/useSummary.ts
@@ -147,8 +147,10 @@ export function useSummary(
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages: [

--- a/packages/web-app-ai-folder-brief-sidebar/src/composables/useFolderBrief.ts
+++ b/packages/web-app-ai-folder-brief-sidebar/src/composables/useFolderBrief.ts
@@ -169,7 +169,8 @@ export function useFolderBrief(
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(30_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages: [{ role: 'user', content: prompt }],

--- a/packages/web-app-ai-folder-brief-sidebar/src/composables/useFolderBrief.ts
+++ b/packages/web-app-ai-folder-brief-sidebar/src/composables/useFolderBrief.ts
@@ -169,8 +169,10 @@ export function useFolderBrief(
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages: [{ role: 'user', content: prompt }],

--- a/packages/web-app-ai-folder-readme-generator/src/composables/useLLM.ts
+++ b/packages/web-app-ai-folder-readme-generator/src/composables/useLLM.ts
@@ -70,7 +70,8 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(60_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,
@@ -91,7 +92,8 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(60_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({ model: cfg.model, messages, stream: true, max_tokens: 1024 })
     })
     if (!r.ok) throw new Error(`LLM stream failed: ${r.status}`)

--- a/packages/web-app-ai-folder-readme-generator/src/composables/useLLM.ts
+++ b/packages/web-app-ai-folder-readme-generator/src/composables/useLLM.ts
@@ -70,8 +70,10 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,
@@ -92,8 +94,10 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({ model: cfg.model, messages, stream: true, max_tokens: 1024 })
     })
     if (!r.ok) throw new Error(`LLM stream failed: ${r.status}`)

--- a/packages/web-app-ai-image-alt-text-sidebar/src/composables/useAltText.ts
+++ b/packages/web-app-ai-image-alt-text-sidebar/src/composables/useAltText.ts
@@ -193,8 +193,10 @@ export function useAltText(
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(cfg.endpoint),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages: [

--- a/packages/web-app-ai-image-alt-text-sidebar/src/composables/useAltText.ts
+++ b/packages/web-app-ai-image-alt-text-sidebar/src/composables/useAltText.ts
@@ -193,7 +193,8 @@ export function useAltText(
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(cfg.endpoint),
-      signal: AbortSignal.timeout(30_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages: [

--- a/packages/web-app-ai-multi-doc-synthesizer/src/composables/useLLM.ts
+++ b/packages/web-app-ai-multi-doc-synthesizer/src/composables/useLLM.ts
@@ -91,8 +91,10 @@ export function useLLM(cfg: LLMConfig): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,

--- a/packages/web-app-ai-multi-doc-synthesizer/src/composables/useLLM.ts
+++ b/packages/web-app-ai-multi-doc-synthesizer/src/composables/useLLM.ts
@@ -91,7 +91,8 @@ export function useLLM(cfg: LLMConfig): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(60_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,

--- a/packages/web-app-ai-quick-draft-creator/src/composables/useLLM.ts
+++ b/packages/web-app-ai-quick-draft-creator/src/composables/useLLM.ts
@@ -59,17 +59,28 @@ export function useLLM(cfg: LLMConfig): UseLLMReturn {
       )
     }
 
-    const r = await fetch(`${base}/chat/completions`, {
-      method: 'POST',
-      headers: buildHeaders(),
-      signal: AbortSignal.timeout(60_000),
-      body: JSON.stringify({
-        model: cfg.model,
-        messages,
-        max_tokens: opts.maxTokens ?? 2048,
-        temperature: opts.temperature ?? 0.7
+    let r: Response
+    try {
+      r = await fetch(`${base}/chat/completions`, {
+        method: 'POST',
+        headers: buildHeaders(),
+        // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+        signal: AbortSignal.timeout(90_000),
+        body: JSON.stringify({
+          model: cfg.model,
+          messages,
+          max_tokens: opts.maxTokens ?? 2048,
+          temperature: opts.temperature ?? 0.7
+        })
       })
-    })
+    } catch (err) {
+      // A timeout abort rejects the fetch itself, before there's any Response to
+      // check .ok on — so this has to be caught here rather than below.
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        throw new Error($gettext('The AI service did not respond in time. Please try again later.'))
+      }
+      throw err
+    }
 
     if (!r.ok) {
       const status = r.status

--- a/packages/web-app-ai-quick-draft-creator/src/composables/useLLM.ts
+++ b/packages/web-app-ai-quick-draft-creator/src/composables/useLLM.ts
@@ -64,8 +64,10 @@ export function useLLM(cfg: LLMConfig): UseLLMReturn {
       r = await fetch(`${base}/chat/completions`, {
         method: 'POST',
         headers: buildHeaders(),
-        // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-        signal: AbortSignal.timeout(90_000),
+        // Generous safety-net ceiling, decoupled from the proxy's own (separately
+        // configurable) upstream timeout; only guards against the network or proxy
+        // never responding at all.
+        signal: AbortSignal.timeout(300_000),
         body: JSON.stringify({
           model: cfg.model,
           messages,

--- a/packages/web-app-ai-sensitive-data-scanner/src/composables/useLlm.ts
+++ b/packages/web-app-ai-sensitive-data-scanner/src/composables/useLlm.ts
@@ -34,7 +34,8 @@ export function useLlm(initialConfig: LlmConfig | null) {
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(30_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,

--- a/packages/web-app-ai-sensitive-data-scanner/src/composables/useLlm.ts
+++ b/packages/web-app-ai-sensitive-data-scanner/src/composables/useLlm.ts
@@ -34,8 +34,10 @@ export function useLlm(initialConfig: LlmConfig | null) {
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,

--- a/packages/web-app-ai-sensitive-data-scanner/src/composables/useScanner.ts
+++ b/packages/web-app-ai-sensitive-data-scanner/src/composables/useScanner.ts
@@ -120,6 +120,13 @@ export function useScanner(llmConfig: LlmConfig | null, resources: Ref<ScanResou
     ].join('\n')
   }
 
+  function handleLlmError(err: unknown): string {
+    if (err instanceof DOMException && err.name === 'TimeoutError') {
+      return $gettext('The AI service did not respond in time. Please try again later.')
+    }
+    return $gettext('The AI service returned an error. Please try again.')
+  }
+
   // Models are instructed to return raw JSON, but frequently wrap it in a markdown
   // code fence (```json ... ``` or ``` ... ```) anyway. Strip that fence before parsing
   // so we don't fall through to treating the whole fenced blob as narrative text.
@@ -242,13 +249,13 @@ export function useScanner(llmConfig: LlmConfig | null, resources: Ref<ScanResou
       const rawContent = data.choices?.[0]?.message?.content ?? '{}'
       const { findings, narrative } = parseLlmResponse(rawContent)
       scanResults.value[index] = { filename, state: 'done', findings, narrative, error: null }
-    } catch {
+    } catch (err) {
       scanResults.value[index] = {
         filename,
         state: 'error',
         findings: [],
         narrative: '',
-        error: $gettext('The AI service returned an error. Please try again.')
+        error: handleLlmError(err)
       }
     }
   }

--- a/packages/web-app-ai-smart-collections-nav/src/composables/useLLM.ts
+++ b/packages/web-app-ai-smart-collections-nav/src/composables/useLLM.ts
@@ -83,7 +83,8 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
           temperature: opts.temperature ?? 0.7,
           ...(opts.responseFormat && { response_format: opts.responseFormat })
         },
-        { signal: AbortSignal.timeout(60_000) }
+        // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+        { signal: AbortSignal.timeout(90_000) }
       )
       const d = response.data as { choices: { message: { content: string } }[] }
       return d.choices[0]?.message?.content ?? ''

--- a/packages/web-app-ai-smart-collections-nav/src/composables/useLLM.ts
+++ b/packages/web-app-ai-smart-collections-nav/src/composables/useLLM.ts
@@ -83,8 +83,10 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
           temperature: opts.temperature ?? 0.7,
           ...(opts.responseFormat && { response_format: opts.responseFormat })
         },
-        // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-        { signal: AbortSignal.timeout(90_000) }
+        // Generous safety-net ceiling, decoupled from the proxy's own (separately
+        // configurable) upstream timeout; only guards against the network or proxy
+        // never responding at all.
+        { signal: AbortSignal.timeout(300_000) }
       )
       const d = response.data as { choices: { message: { content: string } }[] }
       return d.choices[0]?.message?.content ?? ''

--- a/packages/web-app-ai-smart-file-tagger-qa/src/composables/useLLM.ts
+++ b/packages/web-app-ai-smart-file-tagger-qa/src/composables/useLLM.ts
@@ -60,7 +60,8 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(60_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,
@@ -81,7 +82,8 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(60_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({ model: cfg.model, messages, stream: true, max_tokens: 1024 })
     })
     if (!r.ok) throw new Error(`LLM stream failed: ${r.status}`)

--- a/packages/web-app-ai-smart-file-tagger-qa/src/composables/useLLM.ts
+++ b/packages/web-app-ai-smart-file-tagger-qa/src/composables/useLLM.ts
@@ -60,8 +60,10 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: cfg.model,
         messages,
@@ -82,8 +84,10 @@ export function useLLM(cfg: LLMConfig | null): UseLLMReturn {
     const r = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({ model: cfg.model, messages, stream: true, max_tokens: 1024 })
     })
     if (!r.ok) throw new Error(`LLM stream failed: ${r.status}`)

--- a/packages/web-app-chat-with-file/src/composables/useChat.ts
+++ b/packages/web-app-chat-with-file/src/composables/useChat.ts
@@ -264,8 +264,10 @@ export function useChat(
       const res = await fetch(`${base}/chat/completions`, {
         method: 'POST',
         headers: buildHeaders(),
-        // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-        signal: AbortSignal.timeout(90_000),
+        // Generous safety-net ceiling, decoupled from the proxy's own (separately
+        // configurable) upstream timeout; only guards against the network or proxy
+        // never responding at all.
+        signal: AbortSignal.timeout(300_000),
         body: JSON.stringify({ model: cfg.model, messages: requestMessages, max_tokens: 4096 })
       })
 

--- a/packages/web-app-chat-with-file/src/composables/useChat.ts
+++ b/packages/web-app-chat-with-file/src/composables/useChat.ts
@@ -264,7 +264,8 @@ export function useChat(
       const res = await fetch(`${base}/chat/completions`, {
         method: 'POST',
         headers: buildHeaders(),
-        signal: AbortSignal.timeout(60_000),
+        // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+        signal: AbortSignal.timeout(90_000),
         body: JSON.stringify({ model: cfg.model, messages: requestMessages, max_tokens: 4096 })
       })
 

--- a/packages/web-app-version-changelog/src/composables/useChangelog.ts
+++ b/packages/web-app-version-changelog/src/composables/useChangelog.ts
@@ -87,8 +87,10 @@ export function useChangelog(llmConfig: LlmConfig | null | Ref<LlmConfig | null>
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
-      signal: AbortSignal.timeout(90_000),
+      // Generous safety-net ceiling, decoupled from the proxy's own (separately
+      // configurable) upstream timeout; only guards against the network or proxy
+      // never responding at all.
+      signal: AbortSignal.timeout(300_000),
       body: JSON.stringify({
         model: config.model,
         messages: [{ role: 'user', content: prompt }],

--- a/packages/web-app-version-changelog/src/composables/useChangelog.ts
+++ b/packages/web-app-version-changelog/src/composables/useChangelog.ts
@@ -87,7 +87,8 @@ export function useChangelog(llmConfig: LlmConfig | null | Ref<LlmConfig | null>
     const res = await fetch(`${base}/chat/completions`, {
       method: 'POST',
       headers: buildHeaders(),
-      signal: AbortSignal.timeout(30_000),
+      // Must exceed the proxy's own upstream timeout (60s) plus margin for OIDC validation.
+      signal: AbortSignal.timeout(90_000),
       body: JSON.stringify({
         model: config.model,
         messages: [{ role: 'user', content: prompt }],


### PR DESCRIPTION
## Summary

Proactive follow-up (no tracked issue) addressing user-reported "AI proxy requests cancelled mid-flight" behavior. Prior research identified two independent root causes across the client → proxy → upstream LLM request chain, both fixed here.

### Root cause 1 — client-side timeouts fire before the proxy's own timeout, and are inconsistent

Every `web-app-ai-*` (and a couple non-AI) composable calling the `ai-llm-proxy` set its own `AbortSignal.timeout(...)`, with inconsistent values of either 30s or 60s. The proxy itself allows up to 60s for its own upstream LLM fetch, plus unaccounted latency before that for OIDC discovery/userinfo validation. Any composable using the 30s value could abort a request the proxy was still legitimately working on.

**Fix:** raised and unified every client-side `AbortSignal.timeout(...)` call that hits the ai-llm-proxy to `90_000` (90s) — comfortably above the proxy's 60s upstream timeout — with a one-line comment at each call site. Left untouched: the 10s vision-capability probe in `web-app-ai-image-alt-text-sidebar`, and `web-app-ai-smart-collections-nav`'s `useRecentFiles.ts` `REQUEST_TIMEOUT_MS` (a WebDAV REPORT/getFileContents timeout, not an LLM call).

Also added missing `TimeoutError`-specific error handling (matching the message style already used by sibling packages) to the two composables that lacked it entirely:
- `web-app-ai-sensitive-data-scanner` (`useLlm.ts` / `useScanner.ts`)
- `web-app-ai-quick-draft-creator` (`useLLM.ts`) — this one needed the outbound `fetch` wrapped in its own try/catch, since a timeout abort rejects the fetch itself before there's a `Response` to check `.ok` on.

### Root cause 2 — the proxy never notices the client disconnected

In `packages/ai-llm-proxy/src/index.ts`'s `handleRequest`, once the outbound fetch to the LLM endpoint started, there was no listener for the client request's `'close'` event. If the client's own timeout fired, the tab closed, or the connection dropped, the proxy kept awaiting the full upstream LLM response (up to 60s) — burning LLM cost for a response nobody would receive — then tried to write to an already-dead response.

**Fix:**
- Wired an `AbortController` into `handleRequest`, aborted on the request's `'close'` event.
- Combined that controller's signal with the existing upstream timeout via `AbortSignal.any([...])`, so either condition stops the outbound fetch.
- Guarded `sendJson` and the final response write against a disconnected client (`res.writableEnded`/`res.destroyed` checks).
- Attached a no-op `res.on('error', () => {})` listener so a write-after-close can never crash the process via an unhandled `'error'` event.
- Added unit tests proving the outbound fetch's abort signal fires on client disconnect, and that no write/crash occurs afterwards.

## Verification

Per touched package, ran (or the equivalent for `ai-llm-proxy`, which has no `check:types`/`lint` script, so `tsc`/scoped `eslint` were used instead):
- `check:types` — all pass
- `lint` — 0 errors (only pre-existing warnings unrelated to these changes)
- `test:unit` — all pass, including 5 new tests in `packages/ai-llm-proxy/tests/unit/proxy.spec.ts` (28/28 total in that file)

Packages covered: `ai-llm-proxy`, `web-app-ai-data-insights-sidebar`, `web-app-ai-doc-summary`, `web-app-ai-folder-brief-sidebar`, `web-app-ai-folder-readme-generator`, `web-app-ai-image-alt-text-sidebar`, `web-app-ai-multi-doc-synthesizer`, `web-app-ai-quick-draft-creator`, `web-app-ai-sensitive-data-scanner`, `web-app-ai-smart-collections-nav`, `web-app-ai-smart-file-tagger-qa`, `web-app-chat-with-file`, `web-app-version-changelog`.

## Test plan

- [x] `ai-llm-proxy` unit tests cover the new disconnect-abort behavior and write-after-close safety
- [x] Every touched web-app package's existing unit tests still pass with the new timeout value
- [x] Manual read-through of every call site to confirm the 90s value and comment were applied correctly, and that unrelated timeouts (10s vision probe, WebDAV REPORT timeout) were left alone

## Follow-up: client timeout raised from 90s to a 5-minute safety net

The `90_000` (90s) client-side timeout above was chosen to comfortably exceed the proxy's *hardcoded* 60s upstream timeout. However, a separate, still-open PR (#530, `feat/ai-llm-proxy-configurable-timeout`) makes that upstream timeout configurable via `LLM_TIMEOUT_MS` (default unchanged at 60s, but with no fixed upper bound). If an admin sets `LLM_TIMEOUT_MS` above 90s to accommodate a slower self-hosted model, the client's 90s timeout would again fire before the proxy's configured timeout — reintroducing the exact mid-flight cancellation bug this PR fixes, just at a different threshold.

**Fix:** raised every client composable's `AbortSignal.timeout(...)` from `90_000` to `300_000` (5 minutes), and reworded the accompanying comments accordingly. The client-side timeout is no longer meant to closely track the proxy's own upstream timeout — it's now a generous, fixed outer bound whose only job is to prevent the browser tab from hanging indefinitely if the network or the proxy process itself never responds at all (e.g. a killed container, a dropped TCP connection with no FIN, or a proxy that hangs before even starting its upstream fetch). The proxy's own (separately configurable) timeout remains the authoritative, real cutoff for how long an LLM call is allowed to run.

Left untouched: the proxy's own `AbortSignal.timeout(60_000)` in `packages/ai-llm-proxy/src/index.ts` (governed by #530, out of scope here), the 10s vision-capability probe in `web-app-ai-image-alt-text-sidebar`, and `web-app-ai-smart-collections-nav`'s `useRecentFiles.ts` WebDAV timeout.

Verified `check:types`, `lint`, and `test:unit` pass for all 12 touched `web-app-*` packages after the change.