### PR TITLE
feat(web-app-chat-with-file): add expand/collapse toggle to diff view

### DIFF
--- a/packages/web-app-chat-with-file/src/components/ChatPanel.vue
+++ b/packages/web-app-chat-with-file/src/components/ChatPanel.vue
@@ -48,14 +48,30 @@
                     }}
                   </button>
                   <div v-if="!message.applied || isDiffExpanded(index)">
-                    <div v-if="getDiff(index).length > 0" class="diff-block">
+                    <template v-if="getDiff(index).length > 0">
                       <div
-                        v-for="(line, li) in getDiff(index)"
-                        :key="li"
-                        class="diff-line"
-                        :class="`diff-line--${line.type}`"
-                      >{{ diffPrefix(line.type) }}{{ line.text }}</div>
-                    </div>
+                        class="diff-block"
+                        :class="{ 'diff-block--tall': isDiffHeightExpanded(index) }"
+                      >
+                        <div
+                          v-for="(line, li) in getDiff(index)"
+                          :key="li"
+                          class="diff-line"
+                          :class="`diff-line--${line.type}`"
+                        >{{ diffPrefix(line.type) }}{{ line.text }}</div>
+                      </div>
+                      <button
+                        v-if="isDiffLong(index)"
+                        class="diff-height-toggle"
+                        @click="toggleDiffHeight(index)"
+                      >
+                        {{
+                          isDiffHeightExpanded(index)
+                            ? $gettext('Collapse')
+                            : $gettext('Expand')
+                        }}
+                      </button>
+                    </template>
                     <div v-else class="diff-empty">{{ $gettext('No changes detected.') }}</div>
                   </div>
                 </div>
@@ -239,6 +255,24 @@ function getDiff(index: number): FlatLine[] {
   return messageDiffs.value[index] ?? []
 }
 
+const DIFF_LONG_THRESHOLD = 12
+
+function isDiffLong(index: number): boolean {
+  return getDiff(index).length > DIFF_LONG_THRESHOLD
+}
+
+const expandedDiffHeights = ref<number[]>([])
+
+function isDiffHeightExpanded(index: number): boolean {
+  return expandedDiffHeights.value.includes(index)
+}
+
+function toggleDiffHeight(index: number): void {
+  expandedDiffHeights.value = isDiffHeightExpanded(index)
+    ? expandedDiffHeights.value.filter((i) => i !== index)
+    : [...expandedDiffHeights.value, index]
+}
+
 const expandedDiffs = ref<number[]>([])
 
 function isDiffExpanded(index: number): boolean {
@@ -283,6 +317,7 @@ watch(
     if (newId && oldId && newId !== oldId) {
       mode.value = 'chat'
       diffCache.clear()
+      expandedDiffHeights.value = []
     }
   }
 )
@@ -386,6 +421,27 @@ onMounted(() => {
   overflow-x: auto;
   max-height: 260px;
   overflow-y: auto;
+}
+
+.diff-block--tall {
+  max-height: 600px;
+}
+
+.diff-height-toggle {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-family: inherit;
+  color: var(--oc-color-swatch-primary-default, #0d6efd);
+  padding: 4px 0;
+  text-align: center;
+}
+
+.diff-height-toggle:hover {
+  text-decoration: underline;
 }
 
 .diff-line {


### PR DESCRIPTION
## Summary
- Long diffs in the chat-with-file diff view were capped at a fixed max-height with only internal scrolling, making larger proposed edits hard to review.
- Adds an Expand/Collapse button below the diff block (shown once a diff exceeds a line-count threshold) that raises the max-height so the full diff can be read without scrolling.

## Test plan
- [x] `pnpm --filter web-app-chat-with-file check:types`
- [x] `pnpm --filter web-app-chat-with-file lint`
- [x] `pnpm --filter web-app-chat-with-file test:unit` (110 passed)
- [x] Manually verify in the running dev environment: propose an edit with a long diff, confirm Expand/Collapse toggles the taller view