### PR TITLE
test(e2e): wait for upload processing to clear before returning

### DIFF
--- a/support/pages/filesAppBarActions.ts
+++ b/support/pages/filesAppBarActions.ts
@@ -40,5 +40,14 @@ export class FilesAppBar {
     }
     await expect(this.newResourceContextMenu).not.toBeVisible()
     await expect(this.uploadResourceContextMenu).not.toBeVisible()
+
+    // The server keeps a freshly uploaded resource in a "processing" state for a
+    // short while (e.g. content indexing), during which its selection checkbox is
+    // disabled. Wait for that to clear so callers can safely select the resource
+    // right after upload instead of racing against it.
+    const row = this.page
+      .locator('.has-item-context-menu tr')
+      .filter({ has: this.page.locator(`[data-test-resource-name="${file}"]`) })
+    await expect(row.getByRole('checkbox')).toBeEnabled({ timeout: 20_000 })
   }
 }


### PR DESCRIPTION
## Summary
- Fixes a webkit-only flaky test in `web-app-ai-multi-doc-synthesizer`'s `acceptance.spec.ts`, first observed in CI: https://github.com/owncloud/web-extensions/actions/runs/32374559021/job/96443137621?pr=557
- Root cause: oCIS keeps a freshly uploaded resource in a server-side `processing` state for a short while (e.g. content indexing), during which `web-pkg`'s `ResourceTable` disables the row's selection checkbox. The shared `FilesAppBar.uploadFile()` test helper only waited for the upload's HTTP response, not for that processing state to clear, so callers race against it.
- That race produced two related failures:
  - `"Synthesize" is hidden when fewer than 2 files are selected` — `check({ force: true })` bypasses Playwright's normal wait-for-enabled retry, so it failed outright ("Clicking the checkbox did not change its state") while the checkbox was still disabled.
  - `synthesis modal displays shared themes section` — the non-force `selectAllCheckbox.check()` silently retried against the same disabled checkbox, burning most of the 30s test timeout before the following `.click()` on the Synthesize button ran out of budget, surfacing as "Target page, context or browser has been closed".
- Fix: `uploadFile()` now waits for the just-uploaded resource's row checkbox to become enabled before returning. This is a shared helper used by ~12 extension e2e suites, so it addresses the race everywhere it can occur, not just in this one spec.

## Test plan
- [x] `pnpm --filter web-app-ai-multi-doc-synthesizer check:types` and `eslint` on the changed file
- [x] Reproduced CI's setup locally (standalone oCIS container, matching `support/actions/`) and stress-tested the two previously-flaky tests 5x each on webkit: 10/10 passed
- [x] Ran the full `web-app-ai-multi-doc-synthesizer` e2e suite across chrome/firefox/webkit: 33/33 passed